### PR TITLE
Use node --loader instead of ts-node-esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run codegen && npm run compile",
     "compile": "tsc && cp src/schema.graphql dist/schema.graphql",
-    "start": "npm run codegen && ts-node-esm src/server.ts",
+    "start": "npm run codegen && node --loader ts-node/esm src/server.ts",
     "start:dev": "nodemon",
     "codegen": "graphql-codegen-esm --config codegen.yml",
     "lint": "eslint src -c .eslintrc.yml",


### PR DESCRIPTION
Everything's broken for me, and this seems to fix it 🤷‍♂️ 

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/cabeer/Projects/sul-dlss/access/folio-graphql/src/server.ts
    at new NodeError (node:internal/errors:399:5)
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:99:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:139:38)
    at defaultLoad (node:internal/modules/esm/load:83:20)
    at nextLoad (node:internal/modules/esm/hooks:735:28)
    at load (/Users/cabeer/Projects/sul-dlss/access/folio-graphql/node_modules/ts-node/dist/child/child-loader.js:19:122)
    at nextLoad (node:internal/modules/esm/hooks:735:28)
    at Hooks.load (node:internal/modules/esm/hooks:380:26)
    at MessagePort.handleMessage (node:internal/modules/esm/worker:165:24)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:762:20) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}
```