### PR TITLE
Add queueTotalLength to Hold information

### DIFF
--- a/scripts/generate-graphql-from-json-schemas.js
+++ b/scripts/generate-graphql-from-json-schemas.js
@@ -322,7 +322,7 @@ const queryType = new GraphQLObjectType({
       // After all that work, we filter out models that we just don't need. These are the
       // "top level" models we care about, and the GraphQL implementation will figure out
       // their dependencies and drop the rest on the floor.
-      if (['Patron', 'User', 'PatronGroup', 'Instance', 'InstanceNoteType', 'InstanceStatus', 'InstanceType', 'ModeOfIssuance', 'AlternativeTitleType', 'Authority', 'ContributorType', 'HoldingsRecord', 'HoldingsType', 'HoldingsRecordsSource', 'Item', 'ItemDamagedStatus', 'LoanPolicy', 'RequestPolicy', 'Library', 'Loan', 'LoanType', 'CallNumberType', 'ElectronicAccessRelationship', 'PatronGroup', 'Block', 'Account', 'ManualBlock', 'PatronBlockCondition', 'PatronBlockLimit', 'FeeFine', 'ProxyFor', 'FixedDueDateSchedule', 'OverdueFinePolicy', 'LostItemFeePolicy', 'PatronNoticePolicy'].includes(type.name)) {
+      if (['Patron', 'User', 'PatronGroup', 'Instance', 'InstanceNoteType', 'InstanceStatus', 'InstanceType', 'ModeOfIssuance', 'AlternativeTitleType', 'Authority', 'ContributorType', 'HoldingsRecord', 'HoldingsType', 'HoldingsRecordsSource', 'Item', 'ItemDamagedStatus', 'LoanPolicy', 'Request', 'RequestPolicy', 'Library', 'Loan', 'LoanType', 'CallNumberType', 'ElectronicAccessRelationship', 'PatronGroup', 'Block', 'Account', 'ManualBlock', 'PatronBlockCondition', 'PatronBlockLimit', 'FeeFine', 'ProxyFor', 'FixedDueDateSchedule', 'OverdueFinePolicy', 'LostItemFeePolicy', 'PatronNoticePolicy'].includes(type.name)) {
         const n = type.name.charAt(0).toLowerCase() + type.name.slice(1);
 
         result[n] = { type };

--- a/src/folio/circulation-api.ts
+++ b/src/folio/circulation-api.ts
@@ -1,8 +1,17 @@
 import FolioAPI from "./folio-api.js"
-import { Loan } from '../schema'
-
+import { Loan, PatronItem, Request } from '../schema'
 export default class CirculationAPI extends FolioAPI {
   async getLoan(id: string): Promise<Loan> {
     return await this.get<Loan>(`/circulation/loans/${encodeURIComponent(id)}`)
+  }
+  async getRequestQueueLength(item: PatronItem): Promise<number> {
+    let queue;
+    if (item.itemId) {
+      queue = await this.get<Request>(`/circulation/requests/queue/item/${encodeURIComponent(item.itemId)}`)
+    // title-level requests have an instanceId but no itemId
+    } else if (item.instanceId) {
+      queue = await this.get<Request>(`/circulation/requests/queue/instance/${encodeURIComponent(item.instanceId)}`)
+    }
+    return queue?.totalRecords;
   }
 }

--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -176,6 +176,9 @@ export const resolvers: Resolvers = {
         case "Closed - Unfilled": return HoldStatus.ClosedUnfilled
         case "Closed - Pickup expired": return HoldStatus.ClosedPickupExpired
       }
+    },
+    queueTotalLength(parent, args, { dataSources }, info) { 
+      return dataSources.circulation.getRequestQueueLength(parent.item)
     }
   },
   PatronLoan: {

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -379,6 +379,7 @@ export type Hold = {
   pickupLocationId: Scalars['UUID']['output'];
   /** The position in the queue for this patron */
   queuePosition?: Maybe<Scalars['Int']['output']>;
+  queueTotalLength?: Maybe<Scalars['Int']['output']>;
   /** The date when the request was made */
   requestDate: Scalars['DateTime']['output'];
   /** The UUID of the request */
@@ -1588,6 +1589,55 @@ export type OverdueFinePolicy = {
   overdueRecallFine?: Maybe<Quantity>;
 };
 
+/** Blocks to override (e.g. during checkout or renewal) */
+export type OverrideBlocks = {
+  __typename?: 'OverrideBlocks';
+  /** Reason for override */
+  comment?: Maybe<Scalars['String']['output']>;
+  /** Item limit block */
+  itemLimitBlock?: Maybe<OverrideBlocksItemLimitBlock>;
+  /** 'Item not loanable' block */
+  itemNotLoanableBlock?: Maybe<OverrideBlocksItemNotLoanableBlock>;
+  /** Automated patron block */
+  patronBlock?: Maybe<OverrideBlocksPatronBlock>;
+  /** Renewal block */
+  renewalBlock?: Maybe<OverrideBlocksRenewalBlock>;
+  /** Override renewal block which requires due date field */
+  renewalDueDateRequiredBlock?: Maybe<OverrideBlocksRenewalDueDateRequiredBlock>;
+};
+
+/** Item limit block */
+export type OverrideBlocksItemLimitBlock = {
+  __typename?: 'OverrideBlocksItemLimitBlock';
+  _typesWithoutFieldsAreNotAllowed_?: Maybe<Scalars['String']['output']>;
+};
+
+/** 'Item not loanable' block */
+export type OverrideBlocksItemNotLoanableBlock = {
+  __typename?: 'OverrideBlocksItemNotLoanableBlock';
+  /** Due date for a new loan */
+  dueDate: Scalars['DateTime']['output'];
+};
+
+/** Automated patron block */
+export type OverrideBlocksPatronBlock = {
+  __typename?: 'OverrideBlocksPatronBlock';
+  _typesWithoutFieldsAreNotAllowed_?: Maybe<Scalars['String']['output']>;
+};
+
+/** Renewal block */
+export type OverrideBlocksRenewalBlock = {
+  __typename?: 'OverrideBlocksRenewalBlock';
+  _typesWithoutFieldsAreNotAllowed_?: Maybe<Scalars['String']['output']>;
+};
+
+/** Override renewal block which requires due date field */
+export type OverrideBlocksRenewalDueDateRequiredBlock = {
+  __typename?: 'OverrideBlocksRenewalDueDateRequiredBlock';
+  /** Due date for a new loan */
+  dueDate: Scalars['DateTime']['output'];
+};
+
 /** Account schema for patron portal integration */
 export type Patron = {
   __typename?: 'Patron';
@@ -2026,6 +2076,138 @@ export type QueryPatronArgs = {
   id: Scalars['UUID']['input'];
 };
 
+/** Request for an item that might be at a different location or already checked out to another patron */
+export type Request = {
+  __typename?: 'Request';
+  /** Additional information about a cancellation */
+  cancellationAdditionalInformation?: Maybe<Scalars['String']['output']>;
+  /** The id of the request reason */
+  cancellationReasonId?: Maybe<Scalars['UUID']['output']>;
+  /** The id of the user that cancelled the request */
+  cancelledByUserId?: Maybe<Scalars['UUID']['output']>;
+  /** Date the request was cancelled */
+  cancelledDate?: Maybe<Scalars['DateTime']['output']>;
+  /** Address the item is to be delivered to (derived from requester information) */
+  deliveryAddress?: Maybe<RequestDeliveryAddress>;
+  /** Deliver to the address of this type, for the requesting patron */
+  deliveryAddressTypeId?: Maybe<Scalars['UUID']['output']>;
+  /** How should the request be fulfilled (whether the item should be kept on the hold shelf for collection or delivered to the requester) */
+  fulfillmentPreference: RequestFulfillmentPreference;
+  /** Date when an item returned to the hold shelf expires */
+  holdShelfExpirationDate?: Maybe<Scalars['DateTime']['output']>;
+  /** ID of the holdings record being requested */
+  holdingsRecordId?: Maybe<Scalars['UUID']['output']>;
+  /** UUID of the request */
+  id?: Maybe<Scalars['UUID']['output']>;
+  /** Copy of some instance metadata (used for searching and sorting) */
+  instance?: Maybe<RequestInstance>;
+  /** ID of the instance being requested */
+  instanceId?: Maybe<Scalars['UUID']['output']>;
+  /** Copy of some item metadata (used for searching and sorting) */
+  item?: Maybe<RequestItem>;
+  /** ID of the item being requested */
+  itemId?: Maybe<Scalars['UUID']['output']>;
+  /** Metadata about creation and changes to requests, provided by the server (client should not provide) */
+  metadata?: Maybe<Metadata>;
+  /** Comments made by the patron */
+  patronComments?: Maybe<Scalars['String']['output']>;
+  /** The full object of the Service Point record from pickupServicePointId */
+  pickupServicePoint?: Maybe<RequestPickupServicePoint>;
+  /** The ID of the Service Point where this request can be picked up */
+  pickupServicePointId?: Maybe<Scalars['UUID']['output']>;
+  /** position of the request in a per-item request queue */
+  position?: Maybe<Scalars['Int']['output']>;
+  /** Copy of some proxy patron metadata (used for searching and sorting), will be taken from the user referred to by the proxyUserId */
+  proxy?: Maybe<RequestProxy>;
+  /** ID of the user representing a proxy for the patron */
+  proxyUserId?: Maybe<Scalars['UUID']['output']>;
+  /** Date the request was made */
+  requestDate: Scalars['DateTime']['output'];
+  /** Date when the request expires */
+  requestExpirationDate?: Maybe<Scalars['DateTime']['output']>;
+  /** Level of the request - Item or Title */
+  requestLevel?: Maybe<RequestRequestLevel>;
+  /** Additional parameters used for request processing and discarded afterwards. Not part of request record. */
+  requestProcessingParameters?: Maybe<RequestRequestProcessingParameters>;
+  /** Whether the item should be held upon return, recalled or paged for */
+  requestType: RequestRequestType;
+  /** Copy of some requesting patron metadata (used for searching and sorting), will be taken from the user referred to by the requesterId */
+  requester?: Maybe<RequestRequester>;
+  /** ID of the user who made the request */
+  requesterId: Scalars['UUID']['output'];
+  /** Request fields used for search */
+  searchIndex?: Maybe<RequestSearchIndex>;
+  /** Status of the request */
+  status?: Maybe<RequestStatus>;
+  /** Tags */
+  tags?: Maybe<Tags>;
+};
+
+/** Address the item is to be delivered to (derived from requester information) */
+export type RequestDeliveryAddress = {
+  __typename?: 'RequestDeliveryAddress';
+  /** Address line 1 */
+  addressLine1?: Maybe<Scalars['String']['output']>;
+  /** Address line 2 */
+  addressLine2?: Maybe<Scalars['String']['output']>;
+  /** Type of address (refers to address types) */
+  addressTypeId?: Maybe<Scalars['UUID']['output']>;
+  /** City name */
+  city?: Maybe<Scalars['String']['output']>;
+  /** Country code */
+  countryId?: Maybe<Scalars['String']['output']>;
+  /** Postal code */
+  postalCode?: Maybe<Scalars['String']['output']>;
+  /** Region */
+  region?: Maybe<Scalars['String']['output']>;
+};
+
+export enum RequestFulfillmentPreference {
+  Delivery = 'Delivery',
+  HoldShelf = 'Hold_Shelf'
+}
+
+/** Copy of some instance metadata (used for searching and sorting) */
+export type RequestInstance = {
+  __typename?: 'RequestInstance';
+  /** An extensible set of name-value pairs of identifiers associated with the resource */
+  identifiers?: Maybe<Array<RequestInstanceIdentifiersItem>>;
+  /** title of the item */
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type RequestInstanceIdentifiersItem = {
+  __typename?: 'RequestInstanceIdentifiersItem';
+  /** UUID of resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers) */
+  identifierTypeId: Scalars['UUID']['output'];
+  /** Resource identifier value */
+  value: Scalars['String']['output'];
+};
+
+/** Copy of some item metadata (used for searching and sorting) */
+export type RequestItem = {
+  __typename?: 'RequestItem';
+  /** barcode of the item */
+  barcode?: Maybe<Scalars['String']['output']>;
+};
+
+/** The full object of the Service Point record from pickupServicePointId */
+export type RequestPickupServicePoint = {
+  __typename?: 'RequestPickupServicePoint';
+  /** Unique code for the service point */
+  code?: Maybe<Scalars['String']['output']>;
+  /** Description of the service point */
+  description?: Maybe<Scalars['String']['output']>;
+  /** Human-readable name for the service point */
+  discoveryDisplayName?: Maybe<Scalars['String']['output']>;
+  /** Unique name for the service point */
+  name?: Maybe<Scalars['String']['output']>;
+  /** Is this service point a pickup location? */
+  pickupLocation?: Maybe<Scalars['Boolean']['output']>;
+  /** Shelving lag time */
+  shelvingLagTime?: Maybe<Scalars['Int']['output']>;
+};
+
 /** request policy schema */
 export type RequestPolicy = {
   __typename?: 'RequestPolicy';
@@ -2040,6 +2222,112 @@ export type RequestPolicy = {
   /** Whether the item should be held upon return, recalled or paged for */
   requestTypes?: Maybe<Array<RequestType>>;
 };
+
+/** Copy of some proxy patron metadata (used for searching and sorting), will be taken from the user referred to by the proxyUserId */
+export type RequestProxy = {
+  __typename?: 'RequestProxy';
+  /** barcode of the proxy patron (read only, defined by the server) */
+  barcode?: Maybe<Scalars['String']['output']>;
+  /** first name of the proxy patron (read only, defined by the server) */
+  firstName?: Maybe<Scalars['String']['output']>;
+  /** last name of the proxy patron (read only, defined by the server) */
+  lastName?: Maybe<Scalars['String']['output']>;
+  /** middle name of the proxy patron (read only, defined by the server) */
+  middleName?: Maybe<Scalars['String']['output']>;
+  /** record for the user's patrongroup */
+  patronGroup?: Maybe<RequestProxyPatronGroup>;
+  /** UUID for the patrongroup that this user belongs to */
+  patronGroupId?: Maybe<Scalars['UUID']['output']>;
+};
+
+/** record for the user's patrongroup */
+export type RequestProxyPatronGroup = {
+  __typename?: 'RequestProxyPatronGroup';
+  /** A description of the patrongroup */
+  desc?: Maybe<Scalars['String']['output']>;
+  /** The unique name of the patrongroup */
+  group?: Maybe<Scalars['String']['output']>;
+  /** ID of the patrongroup */
+  id?: Maybe<Scalars['UUID']['output']>;
+};
+
+export enum RequestRequestLevel {
+  Item = 'Item'
+}
+
+/** Additional parameters used for request processing and discarded afterwards. Not part of request record. */
+export type RequestRequestProcessingParameters = {
+  __typename?: 'RequestRequestProcessingParameters';
+  /** Blocks to override if user has corresponding permissions */
+  overrideBlocks?: Maybe<OverrideBlocks>;
+};
+
+export enum RequestRequestType {
+  Hold = 'Hold',
+  Page = 'Page',
+  Recall = 'Recall'
+}
+
+/** Copy of some requesting patron metadata (used for searching and sorting), will be taken from the user referred to by the requesterId */
+export type RequestRequester = {
+  __typename?: 'RequestRequester';
+  /** barcode of the patron (read only, defined by the server) */
+  barcode?: Maybe<Scalars['String']['output']>;
+  /** first name of the patron (read only, defined by the server) */
+  firstName?: Maybe<Scalars['String']['output']>;
+  /** last name of the patron (read only, defined by the server) */
+  lastName?: Maybe<Scalars['String']['output']>;
+  /** middle name of the patron (read only, defined by the server) */
+  middleName?: Maybe<Scalars['String']['output']>;
+  /** record for the user's patron group */
+  patronGroup?: Maybe<RequestRequesterPatronGroup>;
+  /** UUID for the patron group that this user belongs to */
+  patronGroupId?: Maybe<Scalars['UUID']['output']>;
+};
+
+/** record for the user's patron group */
+export type RequestRequesterPatronGroup = {
+  __typename?: 'RequestRequesterPatronGroup';
+  /** A description of the patron group */
+  desc?: Maybe<Scalars['String']['output']>;
+  /** The unique name of the patron group */
+  group?: Maybe<Scalars['String']['output']>;
+  /** ID of the patron group */
+  id?: Maybe<Scalars['UUID']['output']>;
+};
+
+/** Request fields used for search */
+export type RequestSearchIndex = {
+  __typename?: 'RequestSearchIndex';
+  /** Effective call number components */
+  callNumberComponents?: Maybe<RequestSearchIndexCallNumberComponents>;
+  /** The name of the request pickup service point */
+  pickupServicePointName?: Maybe<Scalars['String']['output']>;
+  /** A system generated normalization of the call number that allows for call number sorting in reports and search results */
+  shelvingOrder?: Maybe<Scalars['String']['output']>;
+};
+
+/** Effective call number components */
+export type RequestSearchIndexCallNumberComponents = {
+  __typename?: 'RequestSearchIndexCallNumberComponents';
+  /** Effective Call Number is an identifier assigned to an item or its holding and associated with the item. */
+  callNumber?: Maybe<Scalars['String']['output']>;
+  /** Effective Call Number Prefix is the prefix of the identifier assigned to an item or its holding and associated with the item. */
+  prefix?: Maybe<Scalars['String']['output']>;
+  /** Effective Call Number Suffix is the suffix of the identifier assigned to an item or its holding and associated with the item. */
+  suffix?: Maybe<Scalars['String']['output']>;
+};
+
+export enum RequestStatus {
+  ClosedCancelled = 'Closed___Cancelled',
+  ClosedFilled = 'Closed___Filled',
+  ClosedPickupExpired = 'Closed___Pickup_expired',
+  ClosedUnfilled = 'Closed___Unfilled',
+  OpenAwaitingDelivery = 'Open___Awaiting_delivery',
+  OpenAwaitingPickup = 'Open___Awaiting_pickup',
+  OpenInTransit = 'Open___In_transit',
+  OpenNotYetFilled = 'Open___Not_yet_filled'
+}
 
 export enum RequestType {
   Hold = 'Hold',
@@ -2398,6 +2686,12 @@ export type ResolversTypes = ResolversObject<{
   ModeOfIssuance: ResolverTypeWrapper<ModeOfIssuance>;
   Money: ResolverTypeWrapper<Money>;
   OverdueFinePolicy: ResolverTypeWrapper<OverdueFinePolicy>;
+  OverrideBlocks: ResolverTypeWrapper<OverrideBlocks>;
+  OverrideBlocksItemLimitBlock: ResolverTypeWrapper<OverrideBlocksItemLimitBlock>;
+  OverrideBlocksItemNotLoanableBlock: ResolverTypeWrapper<OverrideBlocksItemNotLoanableBlock>;
+  OverrideBlocksPatronBlock: ResolverTypeWrapper<OverrideBlocksPatronBlock>;
+  OverrideBlocksRenewalBlock: ResolverTypeWrapper<OverrideBlocksRenewalBlock>;
+  OverrideBlocksRenewalDueDateRequiredBlock: ResolverTypeWrapper<OverrideBlocksRenewalDueDateRequiredBlock>;
   Patron: ResolverTypeWrapper<Patron>;
   PatronBlockCondition: ResolverTypeWrapper<PatronBlockCondition>;
   PatronBlockConditionValueType: PatronBlockConditionValueType;
@@ -2431,7 +2725,24 @@ export type ResolversTypes = ResolversObject<{
   Quantity: ResolverTypeWrapper<Quantity>;
   QuantityIntervalId: QuantityIntervalId;
   Query: ResolverTypeWrapper<{}>;
+  Request: ResolverTypeWrapper<Request>;
+  RequestDeliveryAddress: ResolverTypeWrapper<RequestDeliveryAddress>;
+  RequestFulfillmentPreference: RequestFulfillmentPreference;
+  RequestInstance: ResolverTypeWrapper<RequestInstance>;
+  RequestInstanceIdentifiersItem: ResolverTypeWrapper<RequestInstanceIdentifiersItem>;
+  RequestItem: ResolverTypeWrapper<RequestItem>;
+  RequestPickupServicePoint: ResolverTypeWrapper<RequestPickupServicePoint>;
   RequestPolicy: ResolverTypeWrapper<RequestPolicy>;
+  RequestProxy: ResolverTypeWrapper<RequestProxy>;
+  RequestProxyPatronGroup: ResolverTypeWrapper<RequestProxyPatronGroup>;
+  RequestRequestLevel: RequestRequestLevel;
+  RequestRequestProcessingParameters: ResolverTypeWrapper<RequestRequestProcessingParameters>;
+  RequestRequestType: RequestRequestType;
+  RequestRequester: ResolverTypeWrapper<RequestRequester>;
+  RequestRequesterPatronGroup: ResolverTypeWrapper<RequestRequesterPatronGroup>;
+  RequestSearchIndex: ResolverTypeWrapper<RequestSearchIndex>;
+  RequestSearchIndexCallNumberComponents: ResolverTypeWrapper<RequestSearchIndexCallNumberComponents>;
+  RequestStatus: RequestStatus;
   RequestType: RequestType;
   Schedule: ResolverTypeWrapper<Schedule>;
   ServicePoint: ResolverTypeWrapper<ServicePoint>;
@@ -2541,6 +2852,12 @@ export type ResolversParentTypes = ResolversObject<{
   ModeOfIssuance: ModeOfIssuance;
   Money: Money;
   OverdueFinePolicy: OverdueFinePolicy;
+  OverrideBlocks: OverrideBlocks;
+  OverrideBlocksItemLimitBlock: OverrideBlocksItemLimitBlock;
+  OverrideBlocksItemNotLoanableBlock: OverrideBlocksItemNotLoanableBlock;
+  OverrideBlocksPatronBlock: OverrideBlocksPatronBlock;
+  OverrideBlocksRenewalBlock: OverrideBlocksRenewalBlock;
+  OverrideBlocksRenewalDueDateRequiredBlock: OverrideBlocksRenewalDueDateRequiredBlock;
   Patron: Patron;
   PatronBlockCondition: PatronBlockCondition;
   PatronBlockLimit: PatronBlockLimit;
@@ -2559,7 +2876,20 @@ export type ResolversParentTypes = ResolversObject<{
   ProxyFor: ProxyFor;
   Quantity: Quantity;
   Query: {};
+  Request: Request;
+  RequestDeliveryAddress: RequestDeliveryAddress;
+  RequestInstance: RequestInstance;
+  RequestInstanceIdentifiersItem: RequestInstanceIdentifiersItem;
+  RequestItem: RequestItem;
+  RequestPickupServicePoint: RequestPickupServicePoint;
   RequestPolicy: RequestPolicy;
+  RequestProxy: RequestProxy;
+  RequestProxyPatronGroup: RequestProxyPatronGroup;
+  RequestRequestProcessingParameters: RequestRequestProcessingParameters;
+  RequestRequester: RequestRequester;
+  RequestRequesterPatronGroup: RequestRequesterPatronGroup;
+  RequestSearchIndex: RequestSearchIndex;
+  RequestSearchIndexCallNumberComponents: RequestSearchIndexCallNumberComponents;
   Schedule: Schedule;
   ServicePoint: ServicePoint;
   ServicepointStaffSlipsItem: ServicepointStaffSlipsItem;
@@ -2792,6 +3122,7 @@ export type HoldResolvers<ContextType = FolioContext, ParentType extends Resolve
   pickupLocation?: Resolver<Maybe<ResolversTypes['ServicePoint']>, ParentType, ContextType>;
   pickupLocationId?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
   queuePosition?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  queueTotalLength?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   requestDate?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   requestId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['HoldStatus']>, ParentType, ContextType>;
@@ -3526,6 +3857,41 @@ export type OverdueFinePolicyResolvers<ContextType = FolioContext, ParentType ex
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type OverrideBlocksResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['OverrideBlocks'] = ResolversParentTypes['OverrideBlocks']> = ResolversObject<{
+  comment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  itemLimitBlock?: Resolver<Maybe<ResolversTypes['OverrideBlocksItemLimitBlock']>, ParentType, ContextType>;
+  itemNotLoanableBlock?: Resolver<Maybe<ResolversTypes['OverrideBlocksItemNotLoanableBlock']>, ParentType, ContextType>;
+  patronBlock?: Resolver<Maybe<ResolversTypes['OverrideBlocksPatronBlock']>, ParentType, ContextType>;
+  renewalBlock?: Resolver<Maybe<ResolversTypes['OverrideBlocksRenewalBlock']>, ParentType, ContextType>;
+  renewalDueDateRequiredBlock?: Resolver<Maybe<ResolversTypes['OverrideBlocksRenewalDueDateRequiredBlock']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OverrideBlocksItemLimitBlockResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['OverrideBlocksItemLimitBlock'] = ResolversParentTypes['OverrideBlocksItemLimitBlock']> = ResolversObject<{
+  _typesWithoutFieldsAreNotAllowed_?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OverrideBlocksItemNotLoanableBlockResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['OverrideBlocksItemNotLoanableBlock'] = ResolversParentTypes['OverrideBlocksItemNotLoanableBlock']> = ResolversObject<{
+  dueDate?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OverrideBlocksPatronBlockResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['OverrideBlocksPatronBlock'] = ResolversParentTypes['OverrideBlocksPatronBlock']> = ResolversObject<{
+  _typesWithoutFieldsAreNotAllowed_?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OverrideBlocksRenewalBlockResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['OverrideBlocksRenewalBlock'] = ResolversParentTypes['OverrideBlocksRenewalBlock']> = ResolversObject<{
+  _typesWithoutFieldsAreNotAllowed_?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type OverrideBlocksRenewalDueDateRequiredBlockResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['OverrideBlocksRenewalDueDateRequiredBlock'] = ResolversParentTypes['OverrideBlocksRenewalDueDateRequiredBlock']> = ResolversObject<{
+  dueDate?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type PatronResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['Patron'] = ResolversParentTypes['Patron']> = ResolversObject<{
   accounts?: Resolver<Array<ResolversTypes['Account']>, ParentType, ContextType>;
   blocks?: Resolver<Array<ResolversTypes['Block']>, ParentType, ContextType>;
@@ -3726,12 +4092,138 @@ export type QueryResolvers<ContextType = FolioContext, ParentType extends Resolv
   requestPolicies?: Resolver<Maybe<Array<Maybe<ResolversTypes['RequestPolicy']>>>, ParentType, ContextType>;
 }>;
 
+export type RequestResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['Request'] = ResolversParentTypes['Request']> = ResolversObject<{
+  cancellationAdditionalInformation?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  cancellationReasonId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  cancelledByUserId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  cancelledDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  deliveryAddress?: Resolver<Maybe<ResolversTypes['RequestDeliveryAddress']>, ParentType, ContextType>;
+  deliveryAddressTypeId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  fulfillmentPreference?: Resolver<ResolversTypes['RequestFulfillmentPreference'], ParentType, ContextType>;
+  holdShelfExpirationDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  holdingsRecordId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  instance?: Resolver<Maybe<ResolversTypes['RequestInstance']>, ParentType, ContextType>;
+  instanceId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  item?: Resolver<Maybe<ResolversTypes['RequestItem']>, ParentType, ContextType>;
+  itemId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  metadata?: Resolver<Maybe<ResolversTypes['Metadata']>, ParentType, ContextType>;
+  patronComments?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  pickupServicePoint?: Resolver<Maybe<ResolversTypes['RequestPickupServicePoint']>, ParentType, ContextType>;
+  pickupServicePointId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  position?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  proxy?: Resolver<Maybe<ResolversTypes['RequestProxy']>, ParentType, ContextType>;
+  proxyUserId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  requestDate?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+  requestExpirationDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  requestLevel?: Resolver<Maybe<ResolversTypes['RequestRequestLevel']>, ParentType, ContextType>;
+  requestProcessingParameters?: Resolver<Maybe<ResolversTypes['RequestRequestProcessingParameters']>, ParentType, ContextType>;
+  requestType?: Resolver<ResolversTypes['RequestRequestType'], ParentType, ContextType>;
+  requester?: Resolver<Maybe<ResolversTypes['RequestRequester']>, ParentType, ContextType>;
+  requesterId?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  searchIndex?: Resolver<Maybe<ResolversTypes['RequestSearchIndex']>, ParentType, ContextType>;
+  status?: Resolver<Maybe<ResolversTypes['RequestStatus']>, ParentType, ContextType>;
+  tags?: Resolver<Maybe<ResolversTypes['Tags']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestDeliveryAddressResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestDeliveryAddress'] = ResolversParentTypes['RequestDeliveryAddress']> = ResolversObject<{
+  addressLine1?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  addressLine2?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  addressTypeId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  city?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  countryId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  postalCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  region?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestInstanceResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestInstance'] = ResolversParentTypes['RequestInstance']> = ResolversObject<{
+  identifiers?: Resolver<Maybe<Array<ResolversTypes['RequestInstanceIdentifiersItem']>>, ParentType, ContextType>;
+  title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestInstanceIdentifiersItemResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestInstanceIdentifiersItem'] = ResolversParentTypes['RequestInstanceIdentifiersItem']> = ResolversObject<{
+  identifierTypeId?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestItemResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestItem'] = ResolversParentTypes['RequestItem']> = ResolversObject<{
+  barcode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestPickupServicePointResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestPickupServicePoint'] = ResolversParentTypes['RequestPickupServicePoint']> = ResolversObject<{
+  code?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  discoveryDisplayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  pickupLocation?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  shelvingLagTime?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type RequestPolicyResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestPolicy'] = ResolversParentTypes['RequestPolicy']> = ResolversObject<{
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['Metadata']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   requestTypes?: Resolver<Maybe<Array<ResolversTypes['RequestType']>>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestProxyResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestProxy'] = ResolversParentTypes['RequestProxy']> = ResolversObject<{
+  barcode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  firstName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  lastName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  middleName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  patronGroup?: Resolver<Maybe<ResolversTypes['RequestProxyPatronGroup']>, ParentType, ContextType>;
+  patronGroupId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestProxyPatronGroupResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestProxyPatronGroup'] = ResolversParentTypes['RequestProxyPatronGroup']> = ResolversObject<{
+  desc?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  group?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestRequestProcessingParametersResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestRequestProcessingParameters'] = ResolversParentTypes['RequestRequestProcessingParameters']> = ResolversObject<{
+  overrideBlocks?: Resolver<Maybe<ResolversTypes['OverrideBlocks']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestRequesterResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestRequester'] = ResolversParentTypes['RequestRequester']> = ResolversObject<{
+  barcode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  firstName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  lastName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  middleName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  patronGroup?: Resolver<Maybe<ResolversTypes['RequestRequesterPatronGroup']>, ParentType, ContextType>;
+  patronGroupId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestRequesterPatronGroupResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestRequesterPatronGroup'] = ResolversParentTypes['RequestRequesterPatronGroup']> = ResolversObject<{
+  desc?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  group?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestSearchIndexResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestSearchIndex'] = ResolversParentTypes['RequestSearchIndex']> = ResolversObject<{
+  callNumberComponents?: Resolver<Maybe<ResolversTypes['RequestSearchIndexCallNumberComponents']>, ParentType, ContextType>;
+  pickupServicePointName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  shelvingOrder?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RequestSearchIndexCallNumberComponentsResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RequestSearchIndexCallNumberComponents'] = ResolversParentTypes['RequestSearchIndexCallNumberComponents']> = ResolversObject<{
+  callNumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  prefix?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  suffix?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -3931,6 +4423,12 @@ export type Resolvers<ContextType = FolioContext> = ResolversObject<{
   ModeOfIssuance?: ModeOfIssuanceResolvers<ContextType>;
   Money?: MoneyResolvers<ContextType>;
   OverdueFinePolicy?: OverdueFinePolicyResolvers<ContextType>;
+  OverrideBlocks?: OverrideBlocksResolvers<ContextType>;
+  OverrideBlocksItemLimitBlock?: OverrideBlocksItemLimitBlockResolvers<ContextType>;
+  OverrideBlocksItemNotLoanableBlock?: OverrideBlocksItemNotLoanableBlockResolvers<ContextType>;
+  OverrideBlocksPatronBlock?: OverrideBlocksPatronBlockResolvers<ContextType>;
+  OverrideBlocksRenewalBlock?: OverrideBlocksRenewalBlockResolvers<ContextType>;
+  OverrideBlocksRenewalDueDateRequiredBlock?: OverrideBlocksRenewalDueDateRequiredBlockResolvers<ContextType>;
   Patron?: PatronResolvers<ContextType>;
   PatronBlockCondition?: PatronBlockConditionResolvers<ContextType>;
   PatronBlockLimit?: PatronBlockLimitResolvers<ContextType>;
@@ -3949,7 +4447,20 @@ export type Resolvers<ContextType = FolioContext> = ResolversObject<{
   ProxyFor?: ProxyForResolvers<ContextType>;
   Quantity?: QuantityResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  Request?: RequestResolvers<ContextType>;
+  RequestDeliveryAddress?: RequestDeliveryAddressResolvers<ContextType>;
+  RequestInstance?: RequestInstanceResolvers<ContextType>;
+  RequestInstanceIdentifiersItem?: RequestInstanceIdentifiersItemResolvers<ContextType>;
+  RequestItem?: RequestItemResolvers<ContextType>;
+  RequestPickupServicePoint?: RequestPickupServicePointResolvers<ContextType>;
   RequestPolicy?: RequestPolicyResolvers<ContextType>;
+  RequestProxy?: RequestProxyResolvers<ContextType>;
+  RequestProxyPatronGroup?: RequestProxyPatronGroupResolvers<ContextType>;
+  RequestRequestProcessingParameters?: RequestRequestProcessingParametersResolvers<ContextType>;
+  RequestRequester?: RequestRequesterResolvers<ContextType>;
+  RequestRequesterPatronGroup?: RequestRequesterPatronGroupResolvers<ContextType>;
+  RequestSearchIndex?: RequestSearchIndexResolvers<ContextType>;
+  RequestSearchIndexCallNumberComponents?: RequestSearchIndexCallNumberComponentsResolvers<ContextType>;
   Schedule?: ScheduleResolvers<ContextType>;
   ServicePoint?: ServicePointResolvers<ContextType>;
   ServicepointStaffSlipsItem?: ServicepointStaffSlipsItemResolvers<ContextType>;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1816,6 +1816,374 @@ type LoanFeesAndFines {
   amountRemainingToPay: Float
 }
 
+"""
+Request for an item that might be at a different location or already checked out to another patron
+"""
+type Request {
+  """UUID of the request"""
+  id: UUID
+
+  """Whether the item should be held upon return, recalled or paged for"""
+  requestType: RequestRequestType!
+
+  """Level of the request - Item or Title"""
+  requestLevel: RequestRequestLevel
+
+  """Date the request was made"""
+  requestDate: DateTime!
+
+  """Comments made by the patron"""
+  patronComments: String
+
+  """ID of the user who made the request"""
+  requesterId: UUID!
+
+  """ID of the user representing a proxy for the patron"""
+  proxyUserId: UUID
+
+  """ID of the instance being requested"""
+  instanceId: UUID
+
+  """ID of the holdings record being requested"""
+  holdingsRecordId: UUID
+
+  """ID of the item being requested"""
+  itemId: UUID
+
+  """Status of the request"""
+  status: RequestStatus
+
+  """The id of the request reason"""
+  cancellationReasonId: UUID
+
+  """The id of the user that cancelled the request"""
+  cancelledByUserId: UUID
+
+  """Additional information about a cancellation"""
+  cancellationAdditionalInformation: String
+
+  """Date the request was cancelled"""
+  cancelledDate: DateTime
+
+  """position of the request in a per-item request queue"""
+  position: Int
+
+  """Copy of some instance metadata (used for searching and sorting)"""
+  instance: RequestInstance
+
+  """Copy of some item metadata (used for searching and sorting)"""
+  item: RequestItem
+
+  """
+  Copy of some requesting patron metadata (used for searching and sorting), will be taken from the user referred to by the requesterId
+  """
+  requester: RequestRequester
+
+  """
+  Copy of some proxy patron metadata (used for searching and sorting), will be taken from the user referred to by the proxyUserId
+  """
+  proxy: RequestProxy
+
+  """
+  How should the request be fulfilled (whether the item should be kept on the hold shelf for collection or delivered to the requester)
+  """
+  fulfillmentPreference: RequestFulfillmentPreference!
+
+  """Deliver to the address of this type, for the requesting patron"""
+  deliveryAddressTypeId: UUID
+
+  """
+  Address the item is to be delivered to (derived from requester information)
+  """
+  deliveryAddress: RequestDeliveryAddress
+
+  """Date when the request expires"""
+  requestExpirationDate: DateTime
+
+  """Date when an item returned to the hold shelf expires"""
+  holdShelfExpirationDate: DateTime
+
+  """The ID of the Service Point where this request can be picked up"""
+  pickupServicePointId: UUID
+
+  """The full object of the Service Point record from pickupServicePointId"""
+  pickupServicePoint: RequestPickupServicePoint
+
+  """Tags"""
+  tags: Tags
+
+  """
+  Metadata about creation and changes to requests, provided by the server (client should not provide)
+  """
+  metadata: Metadata
+
+  """
+  Additional parameters used for request processing and discarded afterwards. Not part of request record.
+  """
+  requestProcessingParameters: RequestRequestProcessingParameters
+
+  """Request fields used for search"""
+  searchIndex: RequestSearchIndex
+}
+
+enum RequestRequestType {
+  Hold
+  Recall
+  Page
+}
+
+enum RequestRequestLevel {
+  Item
+}
+
+enum RequestStatus {
+  Open___Not_yet_filled
+  Open___Awaiting_pickup
+  Open___In_transit
+  Open___Awaiting_delivery
+  Closed___Filled
+  Closed___Cancelled
+  Closed___Unfilled
+  Closed___Pickup_expired
+}
+
+"""Copy of some instance metadata (used for searching and sorting)"""
+type RequestInstance {
+  """title of the item"""
+  title: String
+
+  """
+  An extensible set of name-value pairs of identifiers associated with the resource
+  """
+  identifiers: [RequestInstanceIdentifiersItem!]
+}
+
+type RequestInstanceIdentifiersItem {
+  """Resource identifier value"""
+  value: String!
+
+  """
+  UUID of resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers)
+  """
+  identifierTypeId: UUID!
+}
+
+"""Copy of some item metadata (used for searching and sorting)"""
+type RequestItem {
+  """barcode of the item"""
+  barcode: String
+}
+
+"""
+Copy of some requesting patron metadata (used for searching and sorting), will be taken from the user referred to by the requesterId
+"""
+type RequestRequester {
+  """first name of the patron (read only, defined by the server)"""
+  firstName: String
+
+  """last name of the patron (read only, defined by the server)"""
+  lastName: String
+
+  """middle name of the patron (read only, defined by the server)"""
+  middleName: String
+
+  """barcode of the patron (read only, defined by the server)"""
+  barcode: String
+
+  """UUID for the patron group that this user belongs to"""
+  patronGroupId: UUID
+
+  """record for the user's patron group"""
+  patronGroup: RequestRequesterPatronGroup
+}
+
+"""record for the user's patron group"""
+type RequestRequesterPatronGroup {
+  """ID of the patron group"""
+  id: UUID
+
+  """The unique name of the patron group"""
+  group: String
+
+  """A description of the patron group"""
+  desc: String
+}
+
+"""
+Copy of some proxy patron metadata (used for searching and sorting), will be taken from the user referred to by the proxyUserId
+"""
+type RequestProxy {
+  """first name of the proxy patron (read only, defined by the server)"""
+  firstName: String
+
+  """last name of the proxy patron (read only, defined by the server)"""
+  lastName: String
+
+  """middle name of the proxy patron (read only, defined by the server)"""
+  middleName: String
+
+  """barcode of the proxy patron (read only, defined by the server)"""
+  barcode: String
+
+  """UUID for the patrongroup that this user belongs to"""
+  patronGroupId: UUID
+
+  """record for the user's patrongroup"""
+  patronGroup: RequestProxyPatronGroup
+}
+
+"""record for the user's patrongroup"""
+type RequestProxyPatronGroup {
+  """ID of the patrongroup"""
+  id: UUID
+
+  """The unique name of the patrongroup"""
+  group: String
+
+  """A description of the patrongroup"""
+  desc: String
+}
+
+enum RequestFulfillmentPreference {
+  Hold_Shelf
+  Delivery
+}
+
+"""
+Address the item is to be delivered to (derived from requester information)
+"""
+type RequestDeliveryAddress {
+  """Address line 1"""
+  addressLine1: String
+
+  """Address line 2"""
+  addressLine2: String
+
+  """City name"""
+  city: String
+
+  """Region"""
+  region: String
+
+  """Postal code"""
+  postalCode: String
+
+  """Country code"""
+  countryId: String
+
+  """Type of address (refers to address types)"""
+  addressTypeId: UUID
+}
+
+"""The full object of the Service Point record from pickupServicePointId"""
+type RequestPickupServicePoint {
+  """Unique name for the service point"""
+  name: String
+
+  """Unique code for the service point"""
+  code: String
+
+  """Human-readable name for the service point"""
+  discoveryDisplayName: String
+
+  """Description of the service point"""
+  description: String
+
+  """Shelving lag time"""
+  shelvingLagTime: Int
+
+  """Is this service point a pickup location?"""
+  pickupLocation: Boolean
+}
+
+"""
+Additional parameters used for request processing and discarded afterwards. Not part of request record.
+"""
+type RequestRequestProcessingParameters {
+  """Blocks to override if user has corresponding permissions"""
+  overrideBlocks: OverrideBlocks
+}
+
+"""Blocks to override (e.g. during checkout or renewal)"""
+type OverrideBlocks {
+  """'Item not loanable' block"""
+  itemNotLoanableBlock: OverrideBlocksItemNotLoanableBlock
+
+  """Automated patron block"""
+  patronBlock: OverrideBlocksPatronBlock
+
+  """Item limit block"""
+  itemLimitBlock: OverrideBlocksItemLimitBlock
+
+  """Renewal block"""
+  renewalBlock: OverrideBlocksRenewalBlock
+
+  """Override renewal block which requires due date field"""
+  renewalDueDateRequiredBlock: OverrideBlocksRenewalDueDateRequiredBlock
+
+  """Reason for override"""
+  comment: String
+}
+
+"""'Item not loanable' block"""
+type OverrideBlocksItemNotLoanableBlock {
+  """Due date for a new loan"""
+  dueDate: DateTime!
+}
+
+"""Automated patron block"""
+type OverrideBlocksPatronBlock {
+  _typesWithoutFieldsAreNotAllowed_: String
+}
+
+"""Item limit block"""
+type OverrideBlocksItemLimitBlock {
+  _typesWithoutFieldsAreNotAllowed_: String
+}
+
+"""Renewal block"""
+type OverrideBlocksRenewalBlock {
+  _typesWithoutFieldsAreNotAllowed_: String
+}
+
+"""Override renewal block which requires due date field"""
+type OverrideBlocksRenewalDueDateRequiredBlock {
+  """Due date for a new loan"""
+  dueDate: DateTime!
+}
+
+"""Request fields used for search"""
+type RequestSearchIndex {
+  """Effective call number components"""
+  callNumberComponents: RequestSearchIndexCallNumberComponents
+
+  """
+  A system generated normalization of the call number that allows for call number sorting in reports and search results
+  """
+  shelvingOrder: String
+
+  """The name of the request pickup service point"""
+  pickupServicePointName: String
+}
+
+"""Effective call number components"""
+type RequestSearchIndexCallNumberComponents {
+  """
+  Effective Call Number is an identifier assigned to an item or its holding and associated with the item.
+  """
+  callNumber: String
+
+  """
+  Effective Call Number Prefix is the prefix of the identifier assigned to an item or its holding and associated with the item.
+  """
+  prefix: String
+
+  """
+  Effective Call Number Suffix is the suffix of the identifier assigned to an item or its holding and associated with the item.
+  """
+  suffix: String
+}
+
 """User fines/fees account"""
 type Account {
   """Amount of the fine/fee"""
@@ -2932,6 +3300,7 @@ extend type Loan {
 
 extend type Hold {
   pickupLocation: ServicePoint
+  queueTotalLength: Int
 }
 
 extend type Instance {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -376,6 +376,7 @@ export type Hold = {
   pickupLocationId: Scalars['UUID']['output'];
   /** The position in the queue for this patron */
   queuePosition?: Maybe<Scalars['Int']['output']>;
+  queueTotalLength?: Maybe<Scalars['Int']['output']>;
   /** The date when the request was made */
   requestDate: Scalars['DateTime']['output'];
   /** The UUID of the request */
@@ -1585,6 +1586,55 @@ export type OverdueFinePolicy = {
   overdueRecallFine?: Maybe<Quantity>;
 };
 
+/** Blocks to override (e.g. during checkout or renewal) */
+export type OverrideBlocks = {
+  __typename?: 'OverrideBlocks';
+  /** Reason for override */
+  comment?: Maybe<Scalars['String']['output']>;
+  /** Item limit block */
+  itemLimitBlock?: Maybe<OverrideBlocksItemLimitBlock>;
+  /** 'Item not loanable' block */
+  itemNotLoanableBlock?: Maybe<OverrideBlocksItemNotLoanableBlock>;
+  /** Automated patron block */
+  patronBlock?: Maybe<OverrideBlocksPatronBlock>;
+  /** Renewal block */
+  renewalBlock?: Maybe<OverrideBlocksRenewalBlock>;
+  /** Override renewal block which requires due date field */
+  renewalDueDateRequiredBlock?: Maybe<OverrideBlocksRenewalDueDateRequiredBlock>;
+};
+
+/** Item limit block */
+export type OverrideBlocksItemLimitBlock = {
+  __typename?: 'OverrideBlocksItemLimitBlock';
+  _typesWithoutFieldsAreNotAllowed_?: Maybe<Scalars['String']['output']>;
+};
+
+/** 'Item not loanable' block */
+export type OverrideBlocksItemNotLoanableBlock = {
+  __typename?: 'OverrideBlocksItemNotLoanableBlock';
+  /** Due date for a new loan */
+  dueDate: Scalars['DateTime']['output'];
+};
+
+/** Automated patron block */
+export type OverrideBlocksPatronBlock = {
+  __typename?: 'OverrideBlocksPatronBlock';
+  _typesWithoutFieldsAreNotAllowed_?: Maybe<Scalars['String']['output']>;
+};
+
+/** Renewal block */
+export type OverrideBlocksRenewalBlock = {
+  __typename?: 'OverrideBlocksRenewalBlock';
+  _typesWithoutFieldsAreNotAllowed_?: Maybe<Scalars['String']['output']>;
+};
+
+/** Override renewal block which requires due date field */
+export type OverrideBlocksRenewalDueDateRequiredBlock = {
+  __typename?: 'OverrideBlocksRenewalDueDateRequiredBlock';
+  /** Due date for a new loan */
+  dueDate: Scalars['DateTime']['output'];
+};
+
 /** Account schema for patron portal integration */
 export type Patron = {
   __typename?: 'Patron';
@@ -2023,6 +2073,138 @@ export type QueryPatronArgs = {
   id: Scalars['UUID']['input'];
 };
 
+/** Request for an item that might be at a different location or already checked out to another patron */
+export type Request = {
+  __typename?: 'Request';
+  /** Additional information about a cancellation */
+  cancellationAdditionalInformation?: Maybe<Scalars['String']['output']>;
+  /** The id of the request reason */
+  cancellationReasonId?: Maybe<Scalars['UUID']['output']>;
+  /** The id of the user that cancelled the request */
+  cancelledByUserId?: Maybe<Scalars['UUID']['output']>;
+  /** Date the request was cancelled */
+  cancelledDate?: Maybe<Scalars['DateTime']['output']>;
+  /** Address the item is to be delivered to (derived from requester information) */
+  deliveryAddress?: Maybe<RequestDeliveryAddress>;
+  /** Deliver to the address of this type, for the requesting patron */
+  deliveryAddressTypeId?: Maybe<Scalars['UUID']['output']>;
+  /** How should the request be fulfilled (whether the item should be kept on the hold shelf for collection or delivered to the requester) */
+  fulfillmentPreference: RequestFulfillmentPreference;
+  /** Date when an item returned to the hold shelf expires */
+  holdShelfExpirationDate?: Maybe<Scalars['DateTime']['output']>;
+  /** ID of the holdings record being requested */
+  holdingsRecordId?: Maybe<Scalars['UUID']['output']>;
+  /** UUID of the request */
+  id?: Maybe<Scalars['UUID']['output']>;
+  /** Copy of some instance metadata (used for searching and sorting) */
+  instance?: Maybe<RequestInstance>;
+  /** ID of the instance being requested */
+  instanceId?: Maybe<Scalars['UUID']['output']>;
+  /** Copy of some item metadata (used for searching and sorting) */
+  item?: Maybe<RequestItem>;
+  /** ID of the item being requested */
+  itemId?: Maybe<Scalars['UUID']['output']>;
+  /** Metadata about creation and changes to requests, provided by the server (client should not provide) */
+  metadata?: Maybe<Metadata>;
+  /** Comments made by the patron */
+  patronComments?: Maybe<Scalars['String']['output']>;
+  /** The full object of the Service Point record from pickupServicePointId */
+  pickupServicePoint?: Maybe<RequestPickupServicePoint>;
+  /** The ID of the Service Point where this request can be picked up */
+  pickupServicePointId?: Maybe<Scalars['UUID']['output']>;
+  /** position of the request in a per-item request queue */
+  position?: Maybe<Scalars['Int']['output']>;
+  /** Copy of some proxy patron metadata (used for searching and sorting), will be taken from the user referred to by the proxyUserId */
+  proxy?: Maybe<RequestProxy>;
+  /** ID of the user representing a proxy for the patron */
+  proxyUserId?: Maybe<Scalars['UUID']['output']>;
+  /** Date the request was made */
+  requestDate: Scalars['DateTime']['output'];
+  /** Date when the request expires */
+  requestExpirationDate?: Maybe<Scalars['DateTime']['output']>;
+  /** Level of the request - Item or Title */
+  requestLevel?: Maybe<RequestRequestLevel>;
+  /** Additional parameters used for request processing and discarded afterwards. Not part of request record. */
+  requestProcessingParameters?: Maybe<RequestRequestProcessingParameters>;
+  /** Whether the item should be held upon return, recalled or paged for */
+  requestType: RequestRequestType;
+  /** Copy of some requesting patron metadata (used for searching and sorting), will be taken from the user referred to by the requesterId */
+  requester?: Maybe<RequestRequester>;
+  /** ID of the user who made the request */
+  requesterId: Scalars['UUID']['output'];
+  /** Request fields used for search */
+  searchIndex?: Maybe<RequestSearchIndex>;
+  /** Status of the request */
+  status?: Maybe<RequestStatus>;
+  /** Tags */
+  tags?: Maybe<Tags>;
+};
+
+/** Address the item is to be delivered to (derived from requester information) */
+export type RequestDeliveryAddress = {
+  __typename?: 'RequestDeliveryAddress';
+  /** Address line 1 */
+  addressLine1?: Maybe<Scalars['String']['output']>;
+  /** Address line 2 */
+  addressLine2?: Maybe<Scalars['String']['output']>;
+  /** Type of address (refers to address types) */
+  addressTypeId?: Maybe<Scalars['UUID']['output']>;
+  /** City name */
+  city?: Maybe<Scalars['String']['output']>;
+  /** Country code */
+  countryId?: Maybe<Scalars['String']['output']>;
+  /** Postal code */
+  postalCode?: Maybe<Scalars['String']['output']>;
+  /** Region */
+  region?: Maybe<Scalars['String']['output']>;
+};
+
+export enum RequestFulfillmentPreference {
+  Delivery = 'Delivery',
+  HoldShelf = 'Hold_Shelf'
+}
+
+/** Copy of some instance metadata (used for searching and sorting) */
+export type RequestInstance = {
+  __typename?: 'RequestInstance';
+  /** An extensible set of name-value pairs of identifiers associated with the resource */
+  identifiers?: Maybe<Array<RequestInstanceIdentifiersItem>>;
+  /** title of the item */
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+export type RequestInstanceIdentifiersItem = {
+  __typename?: 'RequestInstanceIdentifiersItem';
+  /** UUID of resource identifier type (e.g. ISBN, ISSN, LCCN, CODEN, Locally defined identifiers) */
+  identifierTypeId: Scalars['UUID']['output'];
+  /** Resource identifier value */
+  value: Scalars['String']['output'];
+};
+
+/** Copy of some item metadata (used for searching and sorting) */
+export type RequestItem = {
+  __typename?: 'RequestItem';
+  /** barcode of the item */
+  barcode?: Maybe<Scalars['String']['output']>;
+};
+
+/** The full object of the Service Point record from pickupServicePointId */
+export type RequestPickupServicePoint = {
+  __typename?: 'RequestPickupServicePoint';
+  /** Unique code for the service point */
+  code?: Maybe<Scalars['String']['output']>;
+  /** Description of the service point */
+  description?: Maybe<Scalars['String']['output']>;
+  /** Human-readable name for the service point */
+  discoveryDisplayName?: Maybe<Scalars['String']['output']>;
+  /** Unique name for the service point */
+  name?: Maybe<Scalars['String']['output']>;
+  /** Is this service point a pickup location? */
+  pickupLocation?: Maybe<Scalars['Boolean']['output']>;
+  /** Shelving lag time */
+  shelvingLagTime?: Maybe<Scalars['Int']['output']>;
+};
+
 /** request policy schema */
 export type RequestPolicy = {
   __typename?: 'RequestPolicy';
@@ -2037,6 +2219,112 @@ export type RequestPolicy = {
   /** Whether the item should be held upon return, recalled or paged for */
   requestTypes?: Maybe<Array<RequestType>>;
 };
+
+/** Copy of some proxy patron metadata (used for searching and sorting), will be taken from the user referred to by the proxyUserId */
+export type RequestProxy = {
+  __typename?: 'RequestProxy';
+  /** barcode of the proxy patron (read only, defined by the server) */
+  barcode?: Maybe<Scalars['String']['output']>;
+  /** first name of the proxy patron (read only, defined by the server) */
+  firstName?: Maybe<Scalars['String']['output']>;
+  /** last name of the proxy patron (read only, defined by the server) */
+  lastName?: Maybe<Scalars['String']['output']>;
+  /** middle name of the proxy patron (read only, defined by the server) */
+  middleName?: Maybe<Scalars['String']['output']>;
+  /** record for the user's patrongroup */
+  patronGroup?: Maybe<RequestProxyPatronGroup>;
+  /** UUID for the patrongroup that this user belongs to */
+  patronGroupId?: Maybe<Scalars['UUID']['output']>;
+};
+
+/** record for the user's patrongroup */
+export type RequestProxyPatronGroup = {
+  __typename?: 'RequestProxyPatronGroup';
+  /** A description of the patrongroup */
+  desc?: Maybe<Scalars['String']['output']>;
+  /** The unique name of the patrongroup */
+  group?: Maybe<Scalars['String']['output']>;
+  /** ID of the patrongroup */
+  id?: Maybe<Scalars['UUID']['output']>;
+};
+
+export enum RequestRequestLevel {
+  Item = 'Item'
+}
+
+/** Additional parameters used for request processing and discarded afterwards. Not part of request record. */
+export type RequestRequestProcessingParameters = {
+  __typename?: 'RequestRequestProcessingParameters';
+  /** Blocks to override if user has corresponding permissions */
+  overrideBlocks?: Maybe<OverrideBlocks>;
+};
+
+export enum RequestRequestType {
+  Hold = 'Hold',
+  Page = 'Page',
+  Recall = 'Recall'
+}
+
+/** Copy of some requesting patron metadata (used for searching and sorting), will be taken from the user referred to by the requesterId */
+export type RequestRequester = {
+  __typename?: 'RequestRequester';
+  /** barcode of the patron (read only, defined by the server) */
+  barcode?: Maybe<Scalars['String']['output']>;
+  /** first name of the patron (read only, defined by the server) */
+  firstName?: Maybe<Scalars['String']['output']>;
+  /** last name of the patron (read only, defined by the server) */
+  lastName?: Maybe<Scalars['String']['output']>;
+  /** middle name of the patron (read only, defined by the server) */
+  middleName?: Maybe<Scalars['String']['output']>;
+  /** record for the user's patron group */
+  patronGroup?: Maybe<RequestRequesterPatronGroup>;
+  /** UUID for the patron group that this user belongs to */
+  patronGroupId?: Maybe<Scalars['UUID']['output']>;
+};
+
+/** record for the user's patron group */
+export type RequestRequesterPatronGroup = {
+  __typename?: 'RequestRequesterPatronGroup';
+  /** A description of the patron group */
+  desc?: Maybe<Scalars['String']['output']>;
+  /** The unique name of the patron group */
+  group?: Maybe<Scalars['String']['output']>;
+  /** ID of the patron group */
+  id?: Maybe<Scalars['UUID']['output']>;
+};
+
+/** Request fields used for search */
+export type RequestSearchIndex = {
+  __typename?: 'RequestSearchIndex';
+  /** Effective call number components */
+  callNumberComponents?: Maybe<RequestSearchIndexCallNumberComponents>;
+  /** The name of the request pickup service point */
+  pickupServicePointName?: Maybe<Scalars['String']['output']>;
+  /** A system generated normalization of the call number that allows for call number sorting in reports and search results */
+  shelvingOrder?: Maybe<Scalars['String']['output']>;
+};
+
+/** Effective call number components */
+export type RequestSearchIndexCallNumberComponents = {
+  __typename?: 'RequestSearchIndexCallNumberComponents';
+  /** Effective Call Number is an identifier assigned to an item or its holding and associated with the item. */
+  callNumber?: Maybe<Scalars['String']['output']>;
+  /** Effective Call Number Prefix is the prefix of the identifier assigned to an item or its holding and associated with the item. */
+  prefix?: Maybe<Scalars['String']['output']>;
+  /** Effective Call Number Suffix is the suffix of the identifier assigned to an item or its holding and associated with the item. */
+  suffix?: Maybe<Scalars['String']['output']>;
+};
+
+export enum RequestStatus {
+  ClosedCancelled = 'Closed___Cancelled',
+  ClosedFilled = 'Closed___Filled',
+  ClosedPickupExpired = 'Closed___Pickup_expired',
+  ClosedUnfilled = 'Closed___Unfilled',
+  OpenAwaitingDelivery = 'Open___Awaiting_delivery',
+  OpenAwaitingPickup = 'Open___Awaiting_pickup',
+  OpenInTransit = 'Open___In_transit',
+  OpenNotYetFilled = 'Open___Not_yet_filled'
+}
 
 export enum RequestType {
   Hold = 'Hold',


### PR DESCRIPTION
This allows the following:
![Screenshot 2023-06-09 at 16 41 47](https://github.com/sul-dlss/folio-graphql/assets/1328900/df906799-890e-432b-b684-d0afd9061e40)


I rebased my branch, re-ran codegen and compile. I am not sure why `resolvers-types` and the the schema have such a big diff or if that is concerning.