### PR TITLE
Guard against missing item data when requesting Holds

### DIFF
--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -218,6 +218,7 @@ export const resolvers: Resolvers = {
       return instances.getInstance(instanceId)
     },
     item({ itemId }, args, { dataSources: { items } }, info) {
+      if (!itemId) return null;
       return items.getItem(itemId)
     }
   },


### PR DESCRIPTION
Holds can be placed at the instance level, in which case they
will contain no item data. In this case, making a request to the
items API will error.

This was blocking the #patron-info method used to populate most
info used in mylibrary, because patrons who had title-level holds
were throwing errors at query time immediately after login.