### PR TITLE
Rename locations API to service point API

### DIFF
--- a/__tests__/setupJest.ts
+++ b/__tests__/setupJest.ts
@@ -9,7 +9,7 @@ import FeeFinesAPI from '../src/folio/feefines-api';
 import HoldingsAPI from '../src/folio/holdings-api';
 import InstancesAPI from '../src/folio/instances-api';
 import ItemsAPI from '../src/folio/items-api';
-import LocationsAPI from '../src/folio/locations-api';
+import ServicePointsAPI from '../src/folio/service-points-api';
 import PatronsAPI from '../src/folio/patrons-api';
 import TypeAPI from '../src/folio/type-api';
 import UsersAPI from '../src/folio/users-api';
@@ -41,7 +41,7 @@ const context: FolioContext = {
   dataSources: {
     patrons: new PatronsAPI(apiOptions),
     users: new UsersAPI(apiOptions),
-    locations: new LocationsAPI(apiOptions),
+    servicepoints: new ServicePointsAPI(apiOptions),
     instances: new InstancesAPI(apiOptions),
     items: new ItemsAPI(apiOptions),
     holdings: new HoldingsAPI(apiOptions),

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
 import PatronsAPI from "./folio/patrons-api.js"
 import UsersAPI from "./folio/users-api.js"
-import LocationsAPI from "./folio/locations-api.js"
+import ServicePointsAPI from "./folio/service-points-api.js"
 import InstancesAPI from "./folio/instances-api.js"
 import ItemsAPI from "./folio/items-api.js"
 import HoldingsAPI from "./folio/holdings-api.js"
@@ -13,7 +13,7 @@ export interface FolioContext {
   dataSources: {
     patrons: PatronsAPI;
     users: UsersAPI;
-    locations: LocationsAPI;
+    servicepoints: ServicePointsAPI;
     instances: InstancesAPI;
     items: ItemsAPI;
     holdings: HoldingsAPI;

--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -162,8 +162,8 @@ export const resolvers: Resolvers = {
     }
   },
   Hold: {
-    pickupLocation({ pickupLocationId }, args, { dataSources: { locations } }, info) {
-      return locations.getLocation(pickupLocationId)
+    pickupLocation({ pickupLocationId }, args, { dataSources: { servicepoints } }, info) {
+      return servicepoints.getServicePoint(pickupLocationId)
     },
     status({ status }, args, context, info) {
       switch(status as unknown as string) {

--- a/src/folio/locations-api.ts
+++ b/src/folio/locations-api.ts
@@ -1,8 +1,0 @@
-import FolioAPI from "./folio-api.js"
-import { ServicePoint } from '../schema'
-
-export default class LocationsAPI extends FolioAPI {
-  async getLocation(id: string): Promise<ServicePoint> {
-    return this.get<ServicePoint>(`/service-points/${encodeURIComponent(id)}`)
-  }
-}

--- a/src/folio/service-points-api.ts
+++ b/src/folio/service-points-api.ts
@@ -1,0 +1,8 @@
+import FolioAPI from "./folio-api.js"
+import { ServicePoint } from '../schema.js'
+
+export default class ServicePointsAPI extends FolioAPI {
+  async getServicePoint(id: string): Promise<ServicePoint> {
+    return this.get<ServicePoint>(`/service-points/${encodeURIComponent(id)}`)
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,7 @@ import Honeybadger from '@honeybadger-io/js';
 import { resolvers } from './folio/index.js';
 import PatronsAPI from "./folio/patrons-api.js"
 import UsersAPI from "./folio/users-api.js"
-import LocationsAPI from "./folio/locations-api.js"
+import ServicePointsAPI from "./folio/service-points-api.js"
 import InstancesAPI from "./folio/instances-api.js"
 import ItemsAPI from "./folio/items-api.js"
 import HoldingsAPI from "./folio/holdings-api.js"
@@ -75,7 +75,7 @@ const context = async ({ req }: Partial<{ req: express.Request }>) => {
     dataSources: {
       patrons: new PatronsAPI({ cache, token }),
       users: new UsersAPI({ cache, token }),
-      locations: new LocationsAPI({ cache, token }),
+      servicepoints: new ServicePointsAPI({ cache, token }),
       instances: new InstancesAPI({ cache, token }),
       items: new ItemsAPI({ cache, token }),
       holdings: new HoldingsAPI({ cache, token }),


### PR DESCRIPTION
Our existing locations API file actually called
(and returned) service point objects. This corrects
the naming so that it's less confusing when we work
with real Location objects later.