### PR TITLE
Add a schema for Location details

### DIFF
--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -370,7 +370,14 @@ export const resolvers: Resolvers = {
     },
     servicePoints({ servicePointIds = [] }, args, { dataSources: { types } }, info) {
       return types.getByIds<ServicePoint>("service-points", { key: "servicepoints" }, servicePointIds)
-    }
+    },
+  },
+  LocationDetails: {
+    pageServicePoints({ pageServicePointIds }, args, { dataSources: { servicepoints } }, info) {
+      if (!pageServicePointIds) return Promise.resolve([])
+
+      return servicepoints.getServicePoints({ 'code': pageServicePointIds.split(",") })
+    },
   },
   Campus: {
     institution({ institutionId }, args, { dataSources: { types } }, info) {

--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -162,8 +162,8 @@ export const resolvers: Resolvers = {
     }
   },
   Hold: {
-    pickupLocation({ pickupLocationId }, args, { dataSources: { servicepoints } }, info) {
-      return servicepoints.getServicePoint(pickupLocationId)
+    pickupLocation({ pickupLocationId }, args, { dataSources: { types } }, info) {
+      return types.getById<ServicePoint>("service-points", { key: "servicepoints" }, pickupLocationId)
     },
     status({ status }, args, context, info) {
       switch(status as unknown as string) {

--- a/src/folio/service-points-api.ts
+++ b/src/folio/service-points-api.ts
@@ -1,8 +1,15 @@
 import FolioAPI from "./folio-api.js"
-import { ServicePoint } from '../schema.js'
+import { CqlParams, ServicePoint } from '../schema.js'
+
+interface ServicePointsResponse {
+  servicepoints: ServicePoint[]
+}
 
 export default class ServicePointsAPI extends FolioAPI {
-  async getServicePoint(id: string): Promise<ServicePoint> {
-    return this.get<ServicePoint>(`/service-points/${encodeURIComponent(id)}`)
+  async getServicePoints(params: Partial<{ params: CqlParams, [key: string]: object | object[] | undefined }>): Promise<ServicePoint[]> {
+    const urlParams = this.buildCqlQuery(params)
+
+    const response = await this.get<ServicePointsResponse>(`/service-points`, { params: urlParams })
+    return response.servicepoints
   }
 }

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -1441,6 +1441,14 @@ export type Location = {
 export type LocationDetails = {
   __typename?: 'LocationDetails';
   _typesWithoutFieldsAreNotAllowed_?: Maybe<Scalars['String']['output']>;
+  /** Site value passed to Aeon to preselect delivery location for material paged from this location */
+  aeonSite?: Maybe<Scalars['String']['output']>;
+  /** Lookup key for user groups who mediate material paged from this location */
+  mediatedPagingGroupKey?: Maybe<Scalars['String']['output']>;
+  /** Comma-separated IDs of valid pickup locations for material paged from the location */
+  pageServicePointIds?: Maybe<Scalars['String']['output']>;
+  /** Valid pickup locations for material paged from this location */
+  pageServicePoints?: Maybe<Array<Maybe<ServicePoint>>>;
 };
 
 /** CRUD to lost item fee policies */
@@ -3770,6 +3778,10 @@ export type LocationResolvers<ContextType = FolioContext, ParentType extends Res
 
 export type LocationDetailsResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['LocationDetails'] = ResolversParentTypes['LocationDetails']> = ResolversObject<{
   _typesWithoutFieldsAreNotAllowed_?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  aeonSite?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  mediatedPagingGroupKey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  pageServicePointIds?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  pageServicePoints?: Resolver<Maybe<Array<Maybe<ResolversTypes['ServicePoint']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -3388,3 +3388,17 @@ extend type LoanPolicyRenewalsPolicy {
 extend type Block {
   blockCondition: PatronBlockCondition
 }
+
+extend type LocationDetails {
+  """Comma-separated IDs of valid pickup locations for material paged from the location"""
+  pageServicePointIds: String
+
+  """Valid pickup locations for material paged from this location"""
+  pageServicePoints: [ServicePoint]
+
+  """Lookup key for user groups who mediate material paged from this location"""
+  mediatedPagingGroupKey: String
+
+  """Site value passed to Aeon to preselect delivery location for material paged from this location"""
+  aeonSite: String
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1438,6 +1438,14 @@ export type Location = {
 export type LocationDetails = {
   __typename?: 'LocationDetails';
   _typesWithoutFieldsAreNotAllowed_?: Maybe<Scalars['String']['output']>;
+  /** Site value passed to Aeon to preselect delivery location for material paged from this location */
+  aeonSite?: Maybe<Scalars['String']['output']>;
+  /** Lookup key for user groups who mediate material paged from this location */
+  mediatedPagingGroupKey?: Maybe<Scalars['String']['output']>;
+  /** Comma-separated IDs of valid pickup locations for material paged from the location */
+  pageServicePointIds?: Maybe<Scalars['String']['output']>;
+  /** Valid pickup locations for material paged from this location */
+  pageServicePoints?: Maybe<Array<Maybe<ServicePoint>>>;
 };
 
 /** CRUD to lost item fee policies */


### PR DESCRIPTION
This adds extra options to the location details object with some
keys and values needed to configure paging for sul-requests.

See https://github.com/sul-dlss/folio-graphql/issues/85

I added some details to a few locations in folio-test; running:
```graphql
query Query {
  locations {
    code
    details {
      aeonSite
      mediatedPagingGroupKey
      pageServicePoints {
        code
        name
      }
    }
  }
}
```
will get you:
```json
{
        "code": "EDU-LOCKED",
        "details": {
          "aeonSite": null,
          "mediatedPagingGroupKey": "EDUCATION",
          "pageServicePoints": [
            {
              "code": "SPEC",
              "name": "Special Collections Desk"
            }
          ]
        }
      },
      {
        "code": "SAL3-PAGE-LP",
        "details": {
          "aeonSite": null,
          "mediatedPagingGroupKey": null,
          "pageServicePoints": [
            {
              "code": "MEDIA-CENTER",
              "name": "Media Center Loan Desk"
            },
            {
              "code": "MUSIC",
              "name": "Music Loan Desk"
            }
          ]
        }
      }
```
which corresponds (in our existing configuration) to the rules:
```yml
  - library: EDUCATION
    locations:
      - LOCKED-STK
    pickup_libraries:
      - SPEC-COLL
    mediated: true
```
and:
```yml
  - locations:
      - PAGE-LP
    pickup_libraries: ['MUSIC', 'MEDIA-MTXT']
```