### PR TITLE
Add scanning-related schema and resolvers for Location details

### DIFF
--- a/__tests__/setupJest.ts
+++ b/__tests__/setupJest.ts
@@ -13,6 +13,7 @@ import ServicePointsAPI from '../src/folio/service-points-api';
 import PatronsAPI from '../src/folio/patrons-api';
 import TypeAPI from '../src/folio/type-api';
 import UsersAPI from '../src/folio/users-api';
+import MaterialTypesAPI from '../src/folio/material-type-api';
 
 // set up fetchMock
 beforeEach(() => {
@@ -48,6 +49,7 @@ const context: FolioContext = {
     types: new TypeAPI(apiOptions),
     feefines: new FeeFinesAPI(apiOptions),
     circulation: new CirculationAPI(apiOptions),
+    materialtypes: new MaterialTypesAPI(apiOptions),
   }
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,6 +7,7 @@ import HoldingsAPI from "./folio/holdings-api.js"
 import TypeAPI from "./folio/type-api.js"
 import FeeFinesAPI from "./folio/feefines-api.js"
 import CirculationAPI from "./folio/circulation-api.js"
+import MaterialTypesAPI from "./folio/material-type-api.js"
 
 export interface FolioContext {
   token: string;
@@ -20,5 +21,6 @@ export interface FolioContext {
     types: TypeAPI;
     feefines: FeeFinesAPI;
     circulation: CirculationAPI;
+    materialtypes: MaterialTypesAPI;
   };
 }

--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -373,8 +373,11 @@ export const resolvers: Resolvers = {
     },
   },
   LocationDetails: {
-    pageServicePoints({ pageServicePointIds }, args, { dataSources: { servicepoints } }, info) {
-      if (!pageServicePointIds) return Promise.resolve([])
+    pageServicePoints({ pageServicePointCodes }, args, { dataSources: { servicepoints } }, info) {
+      if (!pageServicePointCodes) return Promise.resolve([])
+
+      return servicepoints.getServicePoints({ 'code': pageServicePointCodes.split(",") })
+    },
 
       return servicepoints.getServicePoints({ 'code': pageServicePointIds.split(",") })
     },

--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -378,8 +378,10 @@ export const resolvers: Resolvers = {
 
       return servicepoints.getServicePoints({ 'code': pageServicePointCodes.split(",") })
     },
+    scanServicePoint({ scanServicePointCode }, args, { dataSources: { servicepoints } }, info) {
+      if (!scanServicePointCode) return
 
-      return servicepoints.getServicePoints({ 'code': pageServicePointIds.split(",") })
+      return servicepoints.getByCode(scanServicePointCode)
     },
   },
   Campus: {

--- a/src/folio/material-type-api.ts
+++ b/src/folio/material-type-api.ts
@@ -1,0 +1,15 @@
+import FolioAPI from "./folio-api.js"
+import { CqlParams, MaterialType } from '../schema.js'
+
+interface MaterialTypesResponse {
+  mtypes: MaterialType[]
+}
+
+export default class MaterialTypesAPI extends FolioAPI {
+  async getMaterialTypes(params: Partial<{ params: CqlParams, [key: string]: object | object[] | undefined }>): Promise<MaterialType[]> {
+    const urlParams = this.buildCqlQuery(params)
+
+    const response = await this.get<MaterialTypesResponse>(`/material-types`, { params: urlParams })
+    return response.mtypes
+  }
+}

--- a/src/folio/service-points-api.ts
+++ b/src/folio/service-points-api.ts
@@ -6,6 +6,11 @@ interface ServicePointsResponse {
 }
 
 export default class ServicePointsAPI extends FolioAPI {
+  async getByCode(code: string): Promise<ServicePoint> {
+    const servicePoints = await this.getServicePoints({ 'code': [code] })
+    return servicePoints[0]
+  }
+  
   async getServicePoints(params: Partial<{ params: CqlParams, [key: string]: object | object[] | undefined }>): Promise<ServicePoint[]> {
     const urlParams = this.buildCqlQuery(params)
 

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -1442,11 +1442,11 @@ export type LocationDetails = {
   __typename?: 'LocationDetails';
   _typesWithoutFieldsAreNotAllowed_?: Maybe<Scalars['String']['output']>;
   /** Site value passed to Aeon to preselect delivery location for material paged from this location */
-  aeonSite?: Maybe<Scalars['String']['output']>;
+  pageAeonSite?: Maybe<Scalars['String']['output']>;
   /** Lookup key for user groups who mediate material paged from this location */
-  mediatedPagingGroupKey?: Maybe<Scalars['String']['output']>;
-  /** Comma-separated IDs of valid pickup locations for material paged from the location */
-  pageServicePointIds?: Maybe<Scalars['String']['output']>;
+  pageMediationGroupKey?: Maybe<Scalars['String']['output']>;
+  /** Comma-separated codes for valid pickup locations for material paged from this location */
+  pageServicePointCodes?: Maybe<Scalars['String']['output']>;
   /** Valid pickup locations for material paged from this location */
   pageServicePoints?: Maybe<Array<Maybe<ServicePoint>>>;
 };
@@ -3778,9 +3778,9 @@ export type LocationResolvers<ContextType = FolioContext, ParentType extends Res
 
 export type LocationDetailsResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['LocationDetails'] = ResolversParentTypes['LocationDetails']> = ResolversObject<{
   _typesWithoutFieldsAreNotAllowed_?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  aeonSite?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  mediatedPagingGroupKey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  pageServicePointIds?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  pageAeonSite?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  pageMediationGroupKey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  pageServicePointCodes?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   pageServicePoints?: Resolver<Maybe<Array<Maybe<ResolversTypes['ServicePoint']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -10,7 +10,7 @@ export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' |
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string | number; output: string; }
+  ID: { input: string; output: string; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
@@ -1449,6 +1449,10 @@ export type LocationDetails = {
   pageServicePointCodes?: Maybe<Scalars['String']['output']>;
   /** Valid pickup locations for material paged from this location */
   pageServicePoints?: Maybe<Array<Maybe<ServicePoint>>>;
+  /** Service point where material from this location is scanned */
+  scanServicePoint?: Maybe<ServicePoint>;
+  /** Code for service point where material from this location is scanned */
+  scanServicePointCode?: Maybe<Scalars['String']['output']>;
 };
 
 /** CRUD to lost item fee policies */
@@ -3782,6 +3786,8 @@ export type LocationDetailsResolvers<ContextType = FolioContext, ParentType exte
   pageMediationGroupKey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   pageServicePointCodes?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   pageServicePoints?: Resolver<Maybe<Array<Maybe<ResolversTypes['ServicePoint']>>>, ParentType, ContextType>;
+  scanServicePoint?: Resolver<Maybe<ResolversTypes['ServicePoint']>, ParentType, ContextType>;
+  scanServicePointCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -3390,15 +3390,15 @@ extend type Block {
 }
 
 extend type LocationDetails {
-  """Comma-separated IDs of valid pickup locations for material paged from the location"""
-  pageServicePointIds: String
+  """Comma-separated codes for valid pickup locations for material paged from this location"""
+  pageServicePointCodes: String
 
   """Valid pickup locations for material paged from this location"""
   pageServicePoints: [ServicePoint]
 
   """Lookup key for user groups who mediate material paged from this location"""
-  mediatedPagingGroupKey: String
+  pageMediationGroupKey: String
 
   """Site value passed to Aeon to preselect delivery location for material paged from this location"""
-  aeonSite: String
+  pageAeonSite: String
 }

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -3401,4 +3401,10 @@ extend type LocationDetails {
 
   """Site value passed to Aeon to preselect delivery location for material paged from this location"""
   pageAeonSite: String
+
+  """Code for service point where material from this location is scanned"""
+  scanServicePointCode: String
+
+  """Service point where material from this location is scanned"""
+  scanServicePoint: ServicePoint
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1439,11 +1439,11 @@ export type LocationDetails = {
   __typename?: 'LocationDetails';
   _typesWithoutFieldsAreNotAllowed_?: Maybe<Scalars['String']['output']>;
   /** Site value passed to Aeon to preselect delivery location for material paged from this location */
-  aeonSite?: Maybe<Scalars['String']['output']>;
+  pageAeonSite?: Maybe<Scalars['String']['output']>;
   /** Lookup key for user groups who mediate material paged from this location */
-  mediatedPagingGroupKey?: Maybe<Scalars['String']['output']>;
-  /** Comma-separated IDs of valid pickup locations for material paged from the location */
-  pageServicePointIds?: Maybe<Scalars['String']['output']>;
+  pageMediationGroupKey?: Maybe<Scalars['String']['output']>;
+  /** Comma-separated codes for valid pickup locations for material paged from this location */
+  pageServicePointCodes?: Maybe<Scalars['String']['output']>;
   /** Valid pickup locations for material paged from this location */
   pageServicePoints?: Maybe<Array<Maybe<ServicePoint>>>;
 };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -7,7 +7,7 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string | number; output: string; }
+  ID: { input: string; output: string; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
@@ -1446,6 +1446,10 @@ export type LocationDetails = {
   pageServicePointCodes?: Maybe<Scalars['String']['output']>;
   /** Valid pickup locations for material paged from this location */
   pageServicePoints?: Maybe<Array<Maybe<ServicePoint>>>;
+  /** Service point where material from this location is scanned */
+  scanServicePoint?: Maybe<ServicePoint>;
+  /** Code for service point where material from this location is scanned */
+  scanServicePointCode?: Maybe<Scalars['String']['output']>;
 };
 
 /** CRUD to lost item fee policies */

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,7 @@ import HoldingsAPI from "./folio/holdings-api.js"
 import TypeAPI from "./folio/type-api.js"
 import FeeFinesAPI from "./folio/feefines-api.js"
 import CirculationAPI from "./folio/circulation-api.js"
+import MaterialTypesAPI from './folio/material-type-api.js'
 import AuthnAPI from "./folio/authn-api.js"
 import OkapiAPI from "./folio/okapi-api.js"
 import { FolioContext } from './context.js'
@@ -82,6 +83,7 @@ const context = async ({ req }: Partial<{ req: express.Request }>) => {
       types: new TypeAPI({ cache, token, typeCache }),
       feefines: new FeeFinesAPI({ cache, token }),
       circulation: new CirculationAPI({ cache, token }),
+      materialtypes: new MaterialTypesAPI({ cache, token }),
     }
   }
 }


### PR DESCRIPTION
This PR:

- Makes names for paging-related fields more consistent (prefix with `page` to distinguish from `scan`)
- Adds a resolver for finding material types by name, so that we can list them by name in service point details later
- Adds fields for setting the scanning service point in `LocationDetails`

This completes #85.

You can now store configuration for rules like:
```yml
scannable:
  - library: SAL
    locations:
      - HY-PAGE-EA
      - ND-PAGE-EA
    destination:
      key: 'EAST-ASIA'
```

Which will be returned per location as something like:
```json
{
        "id": "1345aaab-bb28-42b0-b6ad-a8981fe806e6",
        "code": "SAL-HY-PAGE-EA",
        "name": "SAL HY Page to East-Asia",
        "details": {
          "scanServicePoint": {
            "id": "58cfd8b4-ee04-4f1a-a74e-4a1771fe5b6b",
            "code": "EAST-ASIA",
            "name": "East Asia Loan Desk"
          },
        }
}
```