### PR TITLE
Clean up and extend feeFine interactions

### DIFF
--- a/scripts/generate-graphql-from-json-schemas.js
+++ b/scripts/generate-graphql-from-json-schemas.js
@@ -287,6 +287,7 @@ const nameMap = {
   'AutomatedPatronBlock': 'Block',
   'Manualblockdata': 'ManualBlock',
   'Feefinedata': 'FeeFine',
+  'Feefineactiondata': 'FeeFineAction',
   'Proxyfor': 'ProxyFor',
   'Userdata': 'User',
   'Usergroup': 'PatronGroup',
@@ -322,7 +323,7 @@ const queryType = new GraphQLObjectType({
       // After all that work, we filter out models that we just don't need. These are the
       // "top level" models we care about, and the GraphQL implementation will figure out
       // their dependencies and drop the rest on the floor.
-      if (['Patron', 'User', 'PatronGroup', 'Instance', 'InstanceNoteType', 'InstanceStatus', 'InstanceType', 'ModeOfIssuance', 'AlternativeTitleType', 'Authority', 'ContributorType', 'HoldingsRecord', 'HoldingsType', 'HoldingsRecordsSource', 'Item', 'ItemDamagedStatus', 'LoanPolicy', 'Request', 'RequestPolicy', 'Library', 'Loan', 'LoanType', 'CallNumberType', 'ElectronicAccessRelationship', 'PatronGroup', 'Block', 'Account', 'ManualBlock', 'PatronBlockCondition', 'PatronBlockLimit', 'FeeFine', 'ProxyFor', 'FixedDueDateSchedule', 'OverdueFinePolicy', 'LostItemFeePolicy', 'PatronNoticePolicy'].includes(type.name)) {
+      if (['Patron', 'User', 'PatronGroup', 'Instance', 'InstanceNoteType', 'InstanceStatus', 'InstanceType', 'ModeOfIssuance', 'AlternativeTitleType', 'Authority', 'ContributorType', 'HoldingsRecord', 'HoldingsType', 'HoldingsRecordsSource', 'Item', 'ItemDamagedStatus', 'LoanPolicy', 'Request', 'RequestPolicy', 'Library', 'Loan', 'LoanType', 'CallNumberType', 'ElectronicAccessRelationship', 'PatronGroup', 'Block', 'Account', 'ManualBlock', 'PatronBlockCondition', 'PatronBlockLimit', 'FeeFine', 'FeeFineAction', 'ProxyFor', 'FixedDueDateSchedule', 'OverdueFinePolicy', 'LostItemFeePolicy', 'PatronNoticePolicy'].includes(type.name)) {
         const n = type.name.charAt(0).toLowerCase() + type.name.slice(1);
 
         result[n] = { type };

--- a/src/folio/feefines-api.ts
+++ b/src/folio/feefines-api.ts
@@ -1,8 +1,19 @@
 import FolioAPI from "./folio-api.js"
-import { FeeFine } from '../schema'
+import { FeeFine, CqlParams } from '../schema'
+
+interface FeeFinesResponse {
+  feefines: FeeFine[]
+}
 
 export default class FeeFinesAPI extends FolioAPI {
   async getFeeFine(id: string): Promise<FeeFine> {
     return this.get<FeeFine>(`/feefines/${encodeURIComponent(id)}`)
+  }
+
+  // Types of fee/fines in the system can be retrieved via an API call (GET /feefines)
+  async getFeeFineTypes(params: Partial<{ params: CqlParams, [key: string]: object | object[] | undefined }>): Promise<FeeFine[]> {
+    const urlParams = this.buildCqlQuery(params)
+    const response = await this.get<FeeFinesResponse>(`/feefines`, { params: urlParams })
+    return response.feefines
   }
 }

--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -404,6 +404,9 @@ export const resolvers: Resolvers = {
     user({ userId }, args, { dataSources: { users } }, info) {
       return users.getUser(userId)
     },
+    actions({ id }, args, { dataSources: { users } }, info) {
+      return users.getFeeFineActions(id)
+    },
     loan({ loanId }, args, { dataSources: { circulation } }, info) {
       return circulation.getLoan(loanId)
     },

--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -396,13 +396,6 @@ export const resolvers: Resolvers = {
       return values.filter(v => v.libraryId == id)
     },
   },
-  PatronCharge: {
-    feeFine({ feeFineId }, args, { dataSources: { feefines } }, info) {
-      if (!feeFineId) return;
-
-      return feefines.getFeeFine(feeFineId)
-    }
-  },
   Account: {
     user({ userId }, args, { dataSources: { users } }, info) {
       return users.getUser(userId)

--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -41,6 +41,9 @@ export const resolvers: Resolvers = {
     patron(parent, { id }, { dataSources: { patrons } }, info) {
       return patrons.getPatron(id)
     },
+    feeFineTypes(parent, args, { dataSources: { feefines } }, info) {
+      return feefines.getFeeFineTypes(args)
+    },
     instance(parent, { id }, { dataSources: { instances } }, info) {
       return instances.getInstance(id)
     },

--- a/src/folio/users-api.ts
+++ b/src/folio/users-api.ts
@@ -1,5 +1,5 @@
 import FolioAPI from "./folio-api.js"
-import { User, Block, CqlParams, ManualBlock, Account, ProxyFor } from '../schema'
+import { User, Block, CqlParams, ManualBlock, Account, ProxyFor, FeeFineAction } from '../schema'
 
 interface AutomatedPatronsBlockResponse {
   automatedPatronBlocks: Block[]
@@ -34,11 +34,17 @@ export default class UsersAPI extends FolioAPI {
     return blocks.manualblocks
   }
 
+  async getFeeFineActions(accountId) {
+    const urlParams = this.buildCqlQuery({ accountId: accountId })
+    const actions = await this.get(`/feefineactions`, { params: urlParams })
+    return actions.feefineactions
+  }
+
+
   async getAccounts(userId: string): Promise<any> {
     const urlParams = this.buildCqlQuery({ userId: userId })
-    const accounts = await this.get<AccountsResponse>(`/accounts`, { params: urlParams })
-
-    return accounts.accounts
+    const response = await this.get<AccountsResponse>(`/accounts`, { params: urlParams })
+    return response.accounts
   }
 
   async getProxiesFor(id: string): Promise<ProxyFor[]> {

--- a/src/folio/users-api.ts
+++ b/src/folio/users-api.ts
@@ -37,7 +37,9 @@ export default class UsersAPI extends FolioAPI {
   async getFeeFineActions(accountId) {
     const urlParams = this.buildCqlQuery({ accountId: accountId })
     const actions = await this.get(`/feefineactions`, { params: urlParams })
-    return actions.feefineactions
+
+    // remove the 'source' attribute from the response because it contains private staff data
+    return actions.feefineactions.map(({source, ...data}) => data)
   }
 
 

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -24,6 +24,7 @@ export type Scalars = {
 /** User fines/fees account */
 export type Account = {
   __typename?: 'Account';
+  actions?: Maybe<Array<Maybe<FeeFineAction>>>;
   /** Amount of the fine/fee */
   amount: Scalars['Float']['output'];
   /** Text, with input likely validated by the barcode scanner */
@@ -344,6 +345,39 @@ export type FeeFine = {
   metadata?: Maybe<Metadata>;
   /** ID of the owner */
   ownerId?: Maybe<Scalars['UUID']['output']>;
+};
+
+/** Transactions or activities associated with a user fee/fine account */
+export type FeeFineAction = {
+  __typename?: 'FeeFineAction';
+  /** ID of the accounts */
+  accountId: Scalars['UUID']['output'];
+  /** Amount of activity */
+  amountAction?: Maybe<Scalars['Float']['output']>;
+  /** Calculated amount of remaining balance based on original fee/fine and what has been paid/waived/transferred/refunded */
+  balance?: Maybe<Scalars['Float']['output']>;
+  /** Additional information entered as part of the activity or on this screen as a 'Staff info only' activity */
+  comments?: Maybe<Scalars['String']['output']>;
+  /** ID of the service point where the action was created */
+  createdAt?: Maybe<Scalars['UUID']['output']>;
+  /** Date and time the transaction of the fine/fee was created */
+  dateAction?: Maybe<Scalars['DateTime']['output']>;
+  /** Fine/fee action id, UUID */
+  id?: Maybe<Scalars['UUID']['output']>;
+  /** A flag to determine if a patron should be notified or not */
+  notify?: Maybe<Scalars['Boolean']['output']>;
+  /** Original invalid (non-UUID) value of 'createdAt' moved here when UUID-validation was enabled for 'createdAt' */
+  originalCreatedAt?: Maybe<Scalars['String']['output']>;
+  /** Overall status of the action-setting */
+  paymentMethod?: Maybe<Scalars['String']['output']>;
+  /** Person who processed activity (from login information) */
+  source?: Maybe<Scalars['String']['output']>;
+  /** Number or other transaction id related to payment */
+  transactionInformation?: Maybe<Scalars['String']['output']>;
+  /** Type of activity including the type of transaction */
+  typeAction?: Maybe<Scalars['String']['output']>;
+  /** ID of the user */
+  userId: Scalars['UUID']['output'];
 };
 
 /** A set of date ranges for materials checkout and their associated due dates. */
@@ -2620,6 +2654,7 @@ export type ResolversTypes = ResolversObject<{
   DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
   ElectronicAccessRelationship: ResolverTypeWrapper<ElectronicAccessRelationship>;
   FeeFine: ResolverTypeWrapper<FeeFine>;
+  FeeFineAction: ResolverTypeWrapper<FeeFineAction>;
   FixedDueDateSchedule: ResolverTypeWrapper<FixedDueDateSchedule>;
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   Hold: ResolverTypeWrapper<Hold>;
@@ -2791,6 +2826,7 @@ export type ResolversParentTypes = ResolversObject<{
   DateTime: Scalars['DateTime']['output'];
   ElectronicAccessRelationship: ElectronicAccessRelationship;
   FeeFine: FeeFine;
+  FeeFineAction: FeeFineAction;
   FixedDueDateSchedule: FixedDueDateSchedule;
   Float: Scalars['Float']['output'];
   Hold: Hold;
@@ -2914,6 +2950,7 @@ export type ResolversParentTypes = ResolversObject<{
 }>;
 
 export type AccountResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['Account'] = ResolversParentTypes['Account']> = ResolversObject<{
+  actions?: Resolver<Maybe<Array<Maybe<ResolversTypes['FeeFineAction']>>>, ParentType, ContextType>;
   amount?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   barcode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   callNumber?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -3108,6 +3145,24 @@ export type FeeFineResolvers<ContextType = FolioContext, ParentType extends Reso
   id?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['Metadata']>, ParentType, ContextType>;
   ownerId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type FeeFineActionResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['FeeFineAction'] = ResolversParentTypes['FeeFineAction']> = ResolversObject<{
+  accountId?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  amountAction?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  balance?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  comments?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  createdAt?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  dateAction?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  id?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  notify?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  originalCreatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  paymentMethod?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  transactionInformation?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  typeAction?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  userId?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -4369,6 +4424,7 @@ export type Resolvers<ContextType = FolioContext> = ResolversObject<{
   DateTime?: GraphQLScalarType;
   ElectronicAccessRelationship?: ElectronicAccessRelationshipResolvers<ContextType>;
   FeeFine?: FeeFineResolvers<ContextType>;
+  FeeFineAction?: FeeFineActionResolvers<ContextType>;
   FixedDueDateSchedule?: FixedDueDateScheduleResolvers<ContextType>;
   Hold?: HoldResolvers<ContextType>;
   HoldingsNoteType?: HoldingsNoteTypeResolvers<ContextType>;

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -2058,6 +2058,7 @@ export enum QuantityIntervalId {
 export type Query = {
   __typename?: 'Query';
   campuses?: Maybe<Array<Maybe<Campus>>>;
+  feeFineTypes?: Maybe<Array<Maybe<FeeFine>>>;
   holdingsRecord?: Maybe<HoldingsRecord>;
   holdingsRecords?: Maybe<Array<Maybe<HoldingsRecord>>>;
   instance?: Maybe<Instance>;
@@ -4141,6 +4142,7 @@ export type QuantityResolvers<ContextType = FolioContext, ParentType extends Res
 
 export type QueryResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
   campuses?: Resolver<Maybe<Array<Maybe<ResolversTypes['Campus']>>>, ParentType, ContextType>;
+  feeFineTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['FeeFine']>>>, ParentType, ContextType>;
   holdingsRecord?: Resolver<Maybe<ResolversTypes['HoldingsRecord']>, ParentType, ContextType, RequireFields<QueryHoldingsRecordArgs, 'id'>>;
   holdingsRecords?: Resolver<Maybe<Array<Maybe<ResolversTypes['HoldingsRecord']>>>, ParentType, ContextType, Partial<QueryHoldingsRecordsArgs>>;
   instance?: Resolver<Maybe<ResolversTypes['Instance']>, ParentType, ContextType, RequireFields<QueryInstanceArgs, 'id'>>;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -3332,7 +3332,6 @@ extend type Account {
   overdueFinePolicyId: UUID
   lostItemFeePolicyId: UUID
   processId: UUID
-
   user: User
   loan: Loan
   item: Item

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -13,6 +13,8 @@ input CqlParams {
 type Query {
   patron(id: UUID!): Patron
 
+  feeFineTypes: [FeeFine]
+
   instance(id: UUID!): Instance
   instances(id: [String], hrid: [String], params: CqlParams): [Instance]
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -2293,6 +2293,57 @@ type AccountdataItemStatus {
   name: String!
 }
 
+"""Transactions or activities associated with a user fee/fine account"""
+type FeeFineAction {
+  """Date and time the transaction of the fine/fee was created"""
+  dateAction: DateTime
+
+  """Type of activity including the type of transaction"""
+  typeAction: String
+
+  """
+  Additional information entered as part of the activity or on this screen as a 'Staff info only' activity
+  """
+  comments: String
+
+  """A flag to determine if a patron should be notified or not"""
+  notify: Boolean
+
+  """Amount of activity"""
+  amountAction: Float
+
+  """
+  Calculated amount of remaining balance based on original fee/fine and what has been paid/waived/transferred/refunded
+  """
+  balance: Float
+
+  """Number or other transaction id related to payment"""
+  transactionInformation: String
+
+  """ID of the service point where the action was created"""
+  createdAt: UUID
+
+  """
+  Original invalid (non-UUID) value of 'createdAt' moved here when UUID-validation was enabled for 'createdAt'
+  """
+  originalCreatedAt: String
+
+  """Person who processed activity (from login information)"""
+  source: String
+
+  """Overall status of the action-setting"""
+  paymentMethod: String
+
+  """ID of the accounts"""
+  accountId: UUID!
+
+  """ID of the user"""
+  userId: UUID!
+
+  """Fine/fee action id, UUID"""
+  id: UUID
+}
+
 """
 Fees/fines that are used by the entire library system. They can be a set of fees / fines shared throughout the library or fees / fines that are unique to a specific customer service
 """
@@ -3286,6 +3337,7 @@ extend type Account {
   loan: Loan
   item: Item
   feeFine: FeeFine
+  actions: [FeeFineAction]
 }
 
 extend type PatronLoan {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2055,6 +2055,7 @@ export enum QuantityIntervalId {
 export type Query = {
   __typename?: 'Query';
   campuses?: Maybe<Array<Maybe<Campus>>>;
+  feeFineTypes?: Maybe<Array<Maybe<FeeFine>>>;
   holdingsRecord?: Maybe<HoldingsRecord>;
   holdingsRecords?: Maybe<Array<Maybe<HoldingsRecord>>>;
   instance?: Maybe<Instance>;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -21,6 +21,7 @@ export type Scalars = {
 /** User fines/fees account */
 export type Account = {
   __typename?: 'Account';
+  actions?: Maybe<Array<Maybe<FeeFineAction>>>;
   /** Amount of the fine/fee */
   amount: Scalars['Float']['output'];
   /** Text, with input likely validated by the barcode scanner */
@@ -341,6 +342,39 @@ export type FeeFine = {
   metadata?: Maybe<Metadata>;
   /** ID of the owner */
   ownerId?: Maybe<Scalars['UUID']['output']>;
+};
+
+/** Transactions or activities associated with a user fee/fine account */
+export type FeeFineAction = {
+  __typename?: 'FeeFineAction';
+  /** ID of the accounts */
+  accountId: Scalars['UUID']['output'];
+  /** Amount of activity */
+  amountAction?: Maybe<Scalars['Float']['output']>;
+  /** Calculated amount of remaining balance based on original fee/fine and what has been paid/waived/transferred/refunded */
+  balance?: Maybe<Scalars['Float']['output']>;
+  /** Additional information entered as part of the activity or on this screen as a 'Staff info only' activity */
+  comments?: Maybe<Scalars['String']['output']>;
+  /** ID of the service point where the action was created */
+  createdAt?: Maybe<Scalars['UUID']['output']>;
+  /** Date and time the transaction of the fine/fee was created */
+  dateAction?: Maybe<Scalars['DateTime']['output']>;
+  /** Fine/fee action id, UUID */
+  id?: Maybe<Scalars['UUID']['output']>;
+  /** A flag to determine if a patron should be notified or not */
+  notify?: Maybe<Scalars['Boolean']['output']>;
+  /** Original invalid (non-UUID) value of 'createdAt' moved here when UUID-validation was enabled for 'createdAt' */
+  originalCreatedAt?: Maybe<Scalars['String']['output']>;
+  /** Overall status of the action-setting */
+  paymentMethod?: Maybe<Scalars['String']['output']>;
+  /** Person who processed activity (from login information) */
+  source?: Maybe<Scalars['String']['output']>;
+  /** Number or other transaction id related to payment */
+  transactionInformation?: Maybe<Scalars['String']['output']>;
+  /** Type of activity including the type of transaction */
+  typeAction?: Maybe<Scalars['String']['output']>;
+  /** ID of the user */
+  userId: Scalars['UUID']['output'];
 };
 
 /** A set of date ranges for materials checkout and their associated due dates. */


### PR DESCRIPTION
I think this will help us with "sequence" and other info required in https://github.com/sul-dlss/mylibrary/issues/830 like the created date (the date of the first action) ?
I didn't see us having access to any Actions in our schema before. However, Actions may be private and internal things we don't want to expose (in this case I can see Sarah's full name returned from the API which seems sketchy, since she created the action on the user) -- in which case can trash this and do it another way!

From the [docs](https://wiki.folio.org/pages/viewpage.action?pageId=73531762):

 _In Folio, fee/fine information is stored as accounts and actions. An account is the umbrella object that is created with a particular charge. An action is always associated with an account, and is where transactions related to a particular charge are stored._

_...An individual user may have zero, one, or more accounts - e.g., if they've never had a fine charged, they would have no account records._

_...Accounts will always have at least one action, created when the account was created.
If an account has been paid, it will have at least two  actions - the one created that shows the initial charge (with a type of "Outstanding",) and then the one that resolves the charge ("______ fully").
_A feefineactiondata record has a required attribute of accountId which links it to the account._


Looks something like:
![Screenshot 2023-06-26 at 16 54 54](https://github.com/sul-dlss/folio-graphql/assets/1328900/0a5bd0b5-017c-4b53-8ed2-a679f26182bf)
