### PR TITLE
Guard against missing loan ID

### DIFF
--- a/src/folio/circulation-api.ts
+++ b/src/folio/circulation-api.ts
@@ -6,6 +6,7 @@ interface LoansResponse {
 
 export default class CirculationAPI extends FolioAPI {
   async getLoan(id: string): Promise<Loan> {
+    if (!id) { return null }
     return await this.get<Loan>(`/circulation/loans/${encodeURIComponent(id)}`)
   }
   async getLoans(params: Partial<{ params: CqlParams, [key: string]: object | object[] | string | undefined }>): Promise<Loan[]> {

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -10,7 +10,7 @@ export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' |
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
+  ID: { input: string | number; output: string; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -7,7 +7,7 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
+  ID: { input: string | number; output: string; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }


### PR DESCRIPTION
I came across errors with this in my current mylibrary work -- accounts/fines are looking for loans, and sometimes there isn't one.