### PR TITLE
Add searchworksTreatTemporaryLocationAsPermanentLocation to location details

### DIFF
--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -1698,6 +1698,8 @@ export type LocationDetails = {
   searchworksGovDocsClassification?: Maybe<Scalars['String']['output']>;
   /** User-visible string for building the Searchworks location_facet */
   searchworksLocationFacetDisplayName?: Maybe<Scalars['String']['output']>;
+  /** We want to treat some locations that are used as temporary locations as if they were the permanent location */
+  searchworksTreatTemporaryLocationAsPermanentLocation?: Maybe<Scalars['String']['output']>;
 };
 
 /** CRUD to lost item fee policies */
@@ -4504,6 +4506,7 @@ export type LocationDetailsResolvers<ContextType = FolioContext, ParentType exte
   scanServicePointCode?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   searchworksGovDocsClassification?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   searchworksLocationFacetDisplayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  searchworksTreatTemporaryLocationAsPermanentLocation?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -4078,6 +4078,9 @@ extend type LocationDetails {
 
   """Some locations imply the type of gov docs they contain"""
   searchworksGovDocsClassification: String
+
+  """We want to treat some locations that are used as temporary locations as if they were the permanent location"""
+  searchworksTreatTemporaryLocationAsPermanentLocation: String
 }
 
 enum LocationAvailabilityClass {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1695,6 +1695,8 @@ export type LocationDetails = {
   searchworksGovDocsClassification?: Maybe<Scalars['String']['output']>;
   /** User-visible string for building the Searchworks location_facet */
   searchworksLocationFacetDisplayName?: Maybe<Scalars['String']['output']>;
+  /** We want to treat some locations that are used as temporary locations as if they were the permanent location */
+  searchworksTreatTemporaryLocationAsPermanentLocation?: Maybe<Scalars['String']['output']>;
 };
 
 /** CRUD to lost item fee policies */


### PR DESCRIPTION
We have some locations (e.g. course reserves) that we always want to treat at the home location in searchworks (e.g. displayed as a separate library/location panel)

See https://github.com/sul-dlss/searchworks_traject_indexer/pull/1086