### PR TITLE
Add RTAC API

### DIFF
--- a/__tests__/setupJest.ts
+++ b/__tests__/setupJest.ts
@@ -15,6 +15,7 @@ import TypeAPI from '../src/folio/type-api';
 import UsersAPI from '../src/folio/users-api';
 import MaterialTypesAPI from '../src/folio/material-type-api';
 import OrdersAPI from '../src/folio/orders-api';
+import RtacApi from '../src/folio/rtac-api';
 
 // set up fetchMock
 beforeEach(() => {
@@ -52,6 +53,7 @@ const context: FolioContext = {
     circulation: new CirculationAPI(apiOptions),
     materialtypes: new MaterialTypesAPI(apiOptions),
     orders: new OrdersAPI(apiOptions),
+    rtac: new RtacApi(apiOptions),
   }
 }
 

--- a/json-schemas/mod-rtac/ramls/deprecated/holding.json
+++ b/json-schemas/mod-rtac/ramls/deprecated/holding.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "RTAC Holding Schema",
+  "type": "object",
+  "description": "Real Time Availability Check (RTAC) holding details",
+  "javaType" : "org.folio.rest.jaxrs.model.LegacyHolding",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "The FOLIO id of the holding (item)"
+    },
+    "location": {
+      "type": "string",
+      "description": "The location of the holding"
+    },
+    "callNumber": {
+      "type": "string",
+      "description": "The call number of the holding"
+    },
+    "status": {
+      "type": "string",
+      "description": "The availability status of the holding"
+    },
+    "dueDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date when the holding will be available"
+    },
+    "volume": {
+      "type": "string",
+      "description": "Volume details for the holding (item)"
+    }
+  },
+  "required": [
+    "id",
+    "location",
+    "callNumber",
+    "status"
+  ]
+}

--- a/json-schemas/mod-rtac/ramls/deprecated/holdings.json
+++ b/json-schemas/mod-rtac/ramls/deprecated/holdings.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "javaType" : "org.folio.rest.jaxrs.model.LegacyHoldings",
+  "description": "Collection of holdings",
+  "properties": {
+    "holdings": {
+      "description": "Collection of holdings",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "holding.json"
+      }
+    }
+  },
+  "required": [
+    "holdings"
+  ]
+}

--- a/json-schemas/mod-rtac/ramls/inventory-hierarchy/inventory-instance-records.json
+++ b/json-schemas/mod-rtac/ramls/inventory-hierarchy/inventory-instance-records.json
@@ -1,0 +1,415 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Response schema for Inventory items and holdings view",
+  "type": "object",
+  "properties": {
+    "instanceId": {
+      "description": "Inventory updated instance identifier",
+      "type": "string",
+      "$ref": "../uuid.json"
+    },
+    "source": {
+      "description": "Source of metadata and format of the underlying record to the instance record",
+      "type": "string"
+    },
+    "modeOfIssuance": {
+      "description": "The mode of issuance would tell if the material is a serial or not",
+      "type": "string"
+    },
+    "natureOfContent": {
+      "description": "A periodical (which is a subset of serials) might also have a nature of content periodical (journal, newspaper)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "holdings": {
+      "type": "array",
+      "description": "Holdings record fields",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "System assigned unique ID of the holdings record",
+            "type": "string",
+            "$ref": "../uuid.json"
+          },
+          "suppressFromDiscovery": {
+            "description": "Indicate if record should not be displayed in a discovery system",
+            "type": "boolean"
+          },
+          "location": {
+            "description": "Holdings record effective location",
+            "type": "object",
+            "properties": {
+              "permanentLocation": {
+                "type": "object",
+                "description": "Permanent shelving location in which an item resides",
+                "properties": {
+                  "name": {
+                    "description": "Name of the (shelf) location",
+                    "type": "string"
+                  },
+                  "campusName": {
+                    "description": "The name of the campus, the second-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "libraryName": {
+                    "description": "The name of the library, the third-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "institutionName": {
+                    "description": "The name of the institution, the first-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "campusName",
+                  "libraryName",
+                  "institutionName"
+                ]
+              },
+              "temporaryLocation": {
+                "type": "object",
+                "description": "Temporary location, shelving location, or holding which is a physical place where items are stored, or an Online location",
+                "properties": {
+                  "name": {
+                    "description": "Name of the (shelf) location",
+                    "type": "string"
+                  },
+                  "campusName": {
+                    "description": "The name of the campus, the second-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "libraryName": {
+                    "description": "The name of the library, the third-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "institutionName": {
+                    "description": "The name of the institution, the first-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "campusName",
+                  "libraryName",
+                  "institutionName"
+                ]
+              }
+            },
+            "required": [
+              "permanentLocation",
+              "temporaryLocation"
+            ]
+          },
+          "callNumber": {
+            "description": "Call Number is an identifier assigned to a holding",
+            "type": "object",
+            "properties": {
+              "prefix": {
+                "description": "Prefix of the call number on the holding level",
+                "type": "string"
+              },
+              "suffix": {
+                "description": "Suffix of the call number on the holding level",
+                "type": "string"
+              },
+              "typeId": {
+                "description": "Unique ID for the type of call number on a holdings record",
+                "type": "string",
+                "$ref": "../uuid.json"
+              },
+              "typeName": {
+                "description": "Name of the call number type",
+                "type": "string"
+              },
+              "callNumber": {
+                "description": "Call Number identifier assigned to a holding",
+                "type": "string"
+              }
+            },
+            "required": [
+              "prefix",
+              "suffix",
+              "typeId",
+              "typeName",
+              "callNumber"
+            ]
+          },
+          "notes": {
+            "description": "Notes about action, copy, binding etc.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "holdingsNoteTypeName": {
+                  "description": "Name of the holdings note type",
+                  "type": "string"
+                },
+                "note": {
+                  "description": "Text content of the note",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "holdingsNoteTypeName",
+                "note"
+              ]
+            }
+          },
+          "holdingsStatements": {
+            "description": "Notes about action, copy, binding etc.",
+            "type": "array",
+            "additionalItems": false,
+            "additionalProperties": false,
+            "items": {
+              "type": "object",
+              "properties": {
+                "statement": {
+                  "description": "Name of the holdings note type",
+                  "type": "string"
+                },
+                "note": {
+                  "description": "Text content of the note",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "statement",
+                "note"
+              ]
+            }
+          },
+          "holdingsStatementsForIndexes": {
+            "description": "Holdings record indexes statements",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "statement": {
+                  "description": "Textual description of the holdings of indexes",
+                  "type": "string"
+                },
+                "note": {
+                  "description": "Note attached to a holdings statement",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "statement",
+                "note"
+              ]
+            }
+          },
+          "holdingsStatementsForSupplements": {
+            "description": "Holdings record supplements statements",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "statement": {
+                  "description": "Textual description of the holdings of supplementary material",
+                  "type": "string"
+                },
+                "note": {
+                  "description": "Note attached to a holdings statement",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "statement",
+                "note"
+              ]
+            }
+          },
+          "copyNumber": {
+            "description": "Piece ID (usually barcode) for systems that do not use holdings record",
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "items": {
+      "type": "array",
+      "description": "Item records",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Unique ID of the item record",
+            "type": "string",
+            "$ref": "../uuid.json"
+          },
+          "holdingsRecordId": {
+            "description": "Unique ID for the type of this holdings record",
+            "type": "string",
+            "$ref": "../uuid.json"
+          },
+          "status": {
+            "description": "The status of the item",
+            "type": "string"
+          },
+          "location": {
+            "description": "Item location",
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "object",
+                "description": "Current home location for the item",
+                "properties": {
+                  "name": {
+                    "description": "Name of the (shelf) location",
+                    "type": "string"
+                  },
+                  "campusName": {
+                    "description": "The name of the campus, the second-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "libraryName": {
+                    "description": "The name of the library, the third-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "institutionName": {
+                    "description": "The name of the institution, the first-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "campusName",
+                  "libraryName",
+                  "institutionName"
+                ]
+              },
+              "permanentLocation": {
+                "type": "object",
+                "description": "Permanent shelving location in which an item resides",
+                "properties": {
+                  "name": {
+                    "description": "Name of the (shelf) location",
+                    "type": "string"
+                  },
+                  "campusName": {
+                    "description": "The name of the campus, the second-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "libraryName": {
+                    "description": "The name of the library, the third-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "institutionName": {
+                    "description": "The name of the institution, the first-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "campusName",
+                  "libraryName",
+                  "institutionName"
+                ]
+              },
+              "temporaryLocation": {
+                "type": "object",
+                "description": "Temporary location, shelving location, or holding which is a physical place where items are stored, or an Online location",
+                "properties": {
+                  "name": {
+                    "description": "Name of the (shelf) location",
+                    "type": "string"
+                  },
+                  "campusName": {
+                    "description": "The name of the campus, the second-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "libraryName": {
+                    "description": "The name of the library, the third-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "institutionName": {
+                    "description": "The name of the institution, the first-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "campusName",
+                  "libraryName",
+                  "institutionName"
+                ]
+              }
+            },
+            "required": [
+              "location",
+              "permanentLocation",
+              "temporaryLocation"
+            ]
+          },
+          "callNumber": {
+            "description": "An identifier assigned to an item, usually printed on a label attached to the item",
+            "type": "object",
+            "properties": {
+              "prefix": {
+                "description": "Prefix of the call number on the item level",
+                "type": "string"
+              },
+              "suffix": {
+                "description": "Suffix of the call number on the item level",
+                "type": "string"
+              },
+              "typeName": {
+                "description": "Name of the call number type",
+                "type": "string"
+              },
+              "callNumber": {
+                "description": "Identifier assigned to an item, used to determine the items physical position in a shelving sequence",
+                "type": "string"
+              }
+            },
+            "required": [
+              "prefix",
+              "suffix",
+              "typeName",
+              "callNumber"
+            ]
+          },
+          "volume": {
+            "description": "Volume is intended for monographs when a multipart monograph",
+            "type": "string"
+          },
+          "enumeration": {
+            "description": "Descriptive information for the numbering scheme of a serial",
+            "type": "string"
+          },
+          "chronology": {
+            "description": "Descriptive information for the dating scheme of a serial",
+            "type": "string"
+          },
+          "itemIdentifier": {
+            "description": "Item identifier number, e.g. imported from the union catalogue",
+            "type": "string"
+          },
+          "permanentLoanType": {
+            "description": "Default loan type for a given item. Loan types are tenant-defined",
+            "type": "string"
+          },
+          "temporaryLoanType": {
+            "description": "Temporary loan type for a given item",
+            "type": "string"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Due date of loan for the item"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "instanceId"
+  ],
+  "additionalProperties": false
+}

--- a/json-schemas/mod-rtac/ramls/rtac-holding.json
+++ b/json-schemas/mod-rtac/ramls/rtac-holding.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "RTAC Holding Schema",
+  "type": "object",
+  "description": "Real Time Availability Check (RTAC) holding details",
+  "additionalProperties": false,
+  "javaType" : "org.folio.rest.jaxrs.model.RtacHolding",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "The FOLIO id of the holding (item)"
+    },
+    "location": {
+      "type": "string",
+      "description": "The location of the holding"
+    },
+    "callNumber": {
+      "type": "string",
+      "description": "The call number of the holding"
+    },
+    "status": {
+      "type": "string",
+      "description": "The availability status of the holding"
+    },
+    "dueDate": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The date when the holding will be available"
+    },
+    "volume": {
+      "type": "string",
+      "description": "Volume details for the holding (item)"
+    },
+    "temporaryLoanType": {
+      "type": "string",
+      "description": "Name of the temporary loan type for a given item"
+    },
+    "permanentLoanType": {
+      "type": "string",
+      "description": "Name of the default loan type for a given item"
+    }
+  },
+  "required": [
+    "id",
+    "location",
+    "callNumber",
+    "status"
+  ]
+}

--- a/json-schemas/mod-rtac/ramls/rtac-holdings-batch.json
+++ b/json-schemas/mod-rtac/ramls/rtac-holdings-batch.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Batch holdings response",
+  "properties": {
+    "holdings": {
+      "description": "Real Time Availability Check (RTAC) holding details",
+      "type": "array",
+      "id": "holdingsList",
+      "items": {
+        "type": "object",
+        "$ref": "rtac-holdings.json"
+      }
+    },
+    "errors": {
+      "description": "Errors",
+      "type": "array",
+      "items": {
+        "$ref": "raml-util/schemas/error.schema"
+      },
+      "minimum": 0
+    }
+  },
+  "additionalItems": false,
+  "additionalProperties": false
+}

--- a/json-schemas/mod-rtac/ramls/rtac-holdings.json
+++ b/json-schemas/mod-rtac/ramls/rtac-holdings.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "description": "Collection of holdings",
+  "javaType" : "org.folio.rest.jaxrs.model.RtacHoldings",
+  "properties": {
+    "instanceId": {
+      "description": "The FOLIO instance identifier",
+      "type": "string",
+      "$ref": "uuid.json"
+    },
+    "holdings": {
+      "description": "Collection of holdings",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "rtac-holding.json"
+      }
+    }
+  },
+  "required": [
+    "holdings"
+  ]
+}

--- a/json-schemas/mod-rtac/ramls/rtac-request.json
+++ b/json-schemas/mod-rtac/ramls/rtac-request.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Define format of request data with instances ids",
+  "type": "object",
+  "properties": {
+    "instanceIds": {
+      "description": "Inventory instances identifiers",
+      "type": "array",
+      "items": {
+        "$ref": "uuid.json"
+      }
+    },
+    "fullPeriodicals": {
+      "description": "if set to true, then item-level information is added to all periodicals without holdings-level information",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "instanceIds"
+  ]
+}

--- a/json-schemas/mod-rtac/ramls/uuid.json
+++ b/json-schemas/mod-rtac/ramls/uuid.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A universally unique identifier (UUID), this is a 128-bit number used to identify a record and is shown in hex with dashes, for example 6312d172-f0cf-40f6-b27d-9fa8feaf332f; the UUID version must be from 1-5; see https://dev.folio.org/guides/uuids/",
+  "type": "string",
+  "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+}

--- a/scripts/generate-graphql-from-json-schemas.js
+++ b/scripts/generate-graphql-from-json-schemas.js
@@ -230,6 +230,12 @@ files.sort().map(file => {
     json.properties.orderCloseReason = { "type": "string" }
   }
 
+  // error.schema internally references parameters.schema, which throws UnknownTypeReference
+  // we just get rid of it, since we don't care about the typing of the error response
+  if (file.includes('/mod-inventory-storage/ramls/raml-util/schemas/error.')) {
+    delete json.properties.parameters
+  }
+
   fixupStuff(file, json)
 
   convert(context, json)
@@ -404,7 +410,8 @@ const queryType = new GraphQLObjectType({
         'PoLineCollection',
         'PoLine',
         'HoldingSummary',
-        'HoldingSummaryCollection'
+        'HoldingSummaryCollection',
+        'RtacHoldingsBatch'
       ];
 
       if (models.includes(type.name)) {

--- a/src/context.ts
+++ b/src/context.ts
@@ -9,6 +9,7 @@ import FeeFinesAPI from "./folio/feefines-api.js"
 import CirculationAPI from "./folio/circulation-api.js"
 import MaterialTypesAPI from "./folio/material-type-api.js"
 import OrdersAPI from "./folio/orders-api.js"
+import RtacApi from "./folio/rtac-api.js"
 
 export interface FolioContext {
   token: string;
@@ -24,5 +25,6 @@ export interface FolioContext {
     circulation: CirculationAPI;
     materialtypes: MaterialTypesAPI;
     orders: OrdersAPI;
+    rtac: RtacApi;
   };
 }

--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -63,6 +63,9 @@ export const resolvers: Resolvers = {
     items(parent, args, { dataSources: { items } }, info) {
       return items.getItems(args)
     },
+    availability(parent, { id }, { dataSources: { rtac } }, info) {
+      return rtac.getAvailability(id)
+    },
 
     // circ rule policies
     loanPolicies(parent, args, { dataSources: { types } }, info) {

--- a/src/folio/rtac-api.ts
+++ b/src/folio/rtac-api.ts
@@ -1,0 +1,28 @@
+import FolioAPI from "./folio-api.js"
+import { RtacHoldingsBatch, RtacHoldings, RtacHolding } from "../schema"
+
+export default class RtacApi extends FolioAPI {
+  // Request real-time availability info for all of the items for a given instance ID
+  async getAvailability(
+    instanceId: string,
+    fullPeriodicals: boolean = true
+  ): Promise<Array<RtacHolding>> {
+    const response = await this.getAvailabilityBatch([instanceId], fullPeriodicals)
+    return response[0].holdings
+  }
+
+  // Request real-time availability info for all of the items for each of the provided instance IDs
+  async getAvailabilityBatch(
+    instanceIds: string[],
+    fullPeriodicals: boolean = true
+  ): Promise<RtacHoldings[]> {
+    const response = await this.post<RtacHoldingsBatch>(`/rtac-batch`, {
+      body: {
+        instanceIds,
+        fullPeriodicals,
+      },
+    })
+
+    return response.holdings
+  }
+}

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -449,6 +449,17 @@ export enum EresourceCreateInventory {
   None = 'None'
 }
 
+/** An error */
+export type Error = {
+  __typename?: 'Error';
+  /** Error message code */
+  code?: Maybe<Scalars['String']['output']>;
+  /** Error message text */
+  message: Scalars['String']['output'];
+  /** Error message type */
+  type?: Maybe<Scalars['String']['output']>;
+};
+
 /** Fees/fines that are used by the entire library system. They can be a set of fees / fines shared throughout the library or fees / fines that are unique to a specific customer service */
 export type FeeFine = {
   __typename?: 'FeeFine';
@@ -2449,6 +2460,7 @@ export enum QuantityIntervalId {
 
 export type Query = {
   __typename?: 'Query';
+  availability?: Maybe<Array<Maybe<RtacHolding>>>;
   campus?: Maybe<Campus>;
   campuses?: Maybe<Array<Maybe<Campus>>>;
   feeFineTypes?: Maybe<Array<Maybe<FeeFine>>>;
@@ -2473,6 +2485,11 @@ export type Query = {
   patronNoticePolicies?: Maybe<Array<Maybe<PatronNoticePolicy>>>;
   requestPolicies?: Maybe<Array<Maybe<RequestPolicy>>>;
   servicePoints?: Maybe<Array<Maybe<ServicePoint>>>;
+};
+
+
+export type QueryAvailabilityArgs = {
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -2770,6 +2787,45 @@ export enum RequestType {
   Page = 'Page',
   Recall = 'Recall'
 }
+
+/** Real Time Availability Check (RTAC) holding details */
+export type RtacHolding = {
+  __typename?: 'RtacHolding';
+  /** The call number of the holding */
+  callNumber: Scalars['String']['output'];
+  /** The date when the holding will be available */
+  dueDate?: Maybe<Scalars['DateTime']['output']>;
+  /** The FOLIO id of the holding (item) */
+  id: Scalars['String']['output'];
+  /** The location of the holding */
+  location: Scalars['String']['output'];
+  /** Name of the default loan type for a given item */
+  permanentLoanType?: Maybe<Scalars['String']['output']>;
+  /** The availability status of the holding */
+  status: Scalars['String']['output'];
+  /** Name of the temporary loan type for a given item */
+  temporaryLoanType?: Maybe<Scalars['String']['output']>;
+  /** Volume details for the holding (item) */
+  volume?: Maybe<Scalars['String']['output']>;
+};
+
+/** Collection of holdings */
+export type RtacHoldings = {
+  __typename?: 'RtacHoldings';
+  /** Collection of holdings */
+  holdings: Array<RtacHolding>;
+  /** The FOLIO instance identifier */
+  instanceId?: Maybe<Scalars['UUID']['output']>;
+};
+
+/** Batch holdings response */
+export type RtacHoldingsBatch = {
+  __typename?: 'RtacHoldingsBatch';
+  /** Errors */
+  errors?: Maybe<Array<Error>>;
+  /** Real Time Availability Check (RTAC) holding details */
+  holdings?: Maybe<Array<RtacHoldings>>;
+};
 
 /** A date range and associated due date, connected with the parent FixedDueDateSchedule. */
 export type Schedule = {
@@ -3106,6 +3162,7 @@ export type ResolversTypes = ResolversObject<{
   ElectronicAccessRelationship: ResolverTypeWrapper<ElectronicAccessRelationship>;
   Eresource: ResolverTypeWrapper<Eresource>;
   EresourceCreateInventory: EresourceCreateInventory;
+  Error: ResolverTypeWrapper<Error>;
   FeeFine: ResolverTypeWrapper<FeeFine>;
   FeeFineAction: ResolverTypeWrapper<FeeFineAction>;
   FixedDueDateSchedule: ResolverTypeWrapper<FixedDueDateSchedule>;
@@ -3253,6 +3310,9 @@ export type ResolversTypes = ResolversObject<{
   RequestRequesterPatronGroup: ResolverTypeWrapper<RequestRequesterPatronGroup>;
   RequestStatus: RequestStatus;
   RequestType: RequestType;
+  RtacHolding: ResolverTypeWrapper<RtacHolding>;
+  RtacHoldings: ResolverTypeWrapper<RtacHoldings>;
+  RtacHoldingsBatch: ResolverTypeWrapper<RtacHoldingsBatch>;
   Schedule: ResolverTypeWrapper<Schedule>;
   ServicePoint: ResolverTypeWrapper<ServicePoint>;
   ServicePointDetails: ResolverTypeWrapper<ServicePointDetails>;
@@ -3299,6 +3359,7 @@ export type ResolversParentTypes = ResolversObject<{
   Details: Details;
   ElectronicAccessRelationship: ElectronicAccessRelationship;
   Eresource: Eresource;
+  Error: Error;
   FeeFine: FeeFine;
   FeeFineAction: FeeFineAction;
   FixedDueDateSchedule: FixedDueDateSchedule;
@@ -3416,6 +3477,9 @@ export type ResolversParentTypes = ResolversObject<{
   RequestRequestProcessingParameters: RequestRequestProcessingParameters;
   RequestRequester: RequestRequester;
   RequestRequesterPatronGroup: RequestRequesterPatronGroup;
+  RtacHolding: RtacHolding;
+  RtacHoldings: RtacHoldings;
+  RtacHoldingsBatch: RtacHoldingsBatch;
   Schedule: Schedule;
   ServicePoint: ServicePoint;
   ServicePointDetails: ServicePointDetails;
@@ -3684,6 +3748,13 @@ export type EresourceResolvers<ContextType = FolioContext, ParentType extends Re
   resourceUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   trial?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   userLimit?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type ErrorResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['Error'] = ResolversParentTypes['Error']> = ResolversObject<{
+  code?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -4830,6 +4901,7 @@ export type QuantityResolvers<ContextType = FolioContext, ParentType extends Res
 }>;
 
 export type QueryResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
+  availability?: Resolver<Maybe<Array<Maybe<ResolversTypes['RtacHolding']>>>, ParentType, ContextType, Partial<QueryAvailabilityArgs>>;
   campus?: Resolver<Maybe<ResolversTypes['Campus']>, ParentType, ContextType, Partial<QueryCampusArgs>>;
   campuses?: Resolver<Maybe<Array<Maybe<ResolversTypes['Campus']>>>, ParentType, ContextType>;
   feeFineTypes?: Resolver<Maybe<Array<Maybe<ResolversTypes['FeeFine']>>>, ParentType, ContextType>;
@@ -4973,6 +5045,30 @@ export type RequestRequesterPatronGroupResolvers<ContextType = FolioContext, Par
   desc?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   group?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RtacHoldingResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RtacHolding'] = ResolversParentTypes['RtacHolding']> = ResolversObject<{
+  callNumber?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  dueDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  location?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  permanentLoanType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  temporaryLoanType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  volume?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RtacHoldingsResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RtacHoldings'] = ResolversParentTypes['RtacHoldings']> = ResolversObject<{
+  holdings?: Resolver<Array<ResolversTypes['RtacHolding']>, ParentType, ContextType>;
+  instanceId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type RtacHoldingsBatchResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['RtacHoldingsBatch'] = ResolversParentTypes['RtacHoldingsBatch']> = ResolversObject<{
+  errors?: Resolver<Maybe<Array<ResolversTypes['Error']>>, ParentType, ContextType>;
+  holdings?: Resolver<Maybe<Array<ResolversTypes['RtacHoldings']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -5147,6 +5243,7 @@ export type Resolvers<ContextType = FolioContext> = ResolversObject<{
   Details?: DetailsResolvers<ContextType>;
   ElectronicAccessRelationship?: ElectronicAccessRelationshipResolvers<ContextType>;
   Eresource?: EresourceResolvers<ContextType>;
+  Error?: ErrorResolvers<ContextType>;
   FeeFine?: FeeFineResolvers<ContextType>;
   FeeFineAction?: FeeFineActionResolvers<ContextType>;
   FixedDueDateSchedule?: FixedDueDateScheduleResolvers<ContextType>;
@@ -5262,6 +5359,9 @@ export type Resolvers<ContextType = FolioContext> = ResolversObject<{
   RequestRequestProcessingParameters?: RequestRequestProcessingParametersResolvers<ContextType>;
   RequestRequester?: RequestRequesterResolvers<ContextType>;
   RequestRequesterPatronGroup?: RequestRequesterPatronGroupResolvers<ContextType>;
+  RtacHolding?: RtacHoldingResolvers<ContextType>;
+  RtacHoldings?: RtacHoldingsResolvers<ContextType>;
+  RtacHoldingsBatch?: RtacHoldingsBatchResolvers<ContextType>;
   Schedule?: ScheduleResolvers<ContextType>;
   ServicePoint?: ServicePointResolvers<ContextType>;
   ServicePointDetails?: ServicePointDetailsResolvers<ContextType>;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -24,6 +24,8 @@ type Query {
   item(id: UUID!): Item
   items(id: [String], hrid: [String], params: CqlParams): [Item]
 
+  availability(id: String): [RtacHolding]
+
   # circ rule policies
   loanPolicies: [LoanPolicy]
   requestPolicies: [RequestPolicy]
@@ -3616,6 +3618,63 @@ type PatronBlockLimit {
   """Limit value"""
   value: Float!
   metadata: Metadata
+}
+
+"""Batch holdings response"""
+type RtacHoldingsBatch {
+  """Real Time Availability Check (RTAC) holding details"""
+  holdings: [RtacHoldings!]
+
+  """Errors"""
+  errors: [Error!]
+}
+
+"""Collection of holdings"""
+type RtacHoldings {
+  """The FOLIO instance identifier"""
+  instanceId: UUID
+
+  """Collection of holdings"""
+  holdings: [RtacHolding!]!
+}
+
+"""Real Time Availability Check (RTAC) holding details"""
+type RtacHolding {
+  """The FOLIO id of the holding (item)"""
+  id: String!
+
+  """The location of the holding"""
+  location: String!
+
+  """The call number of the holding"""
+  callNumber: String!
+
+  """The availability status of the holding"""
+  status: String!
+
+  """The date when the holding will be available"""
+  dueDate: DateTime
+
+  """Volume details for the holding (item)"""
+  volume: String
+
+  """Name of the temporary loan type for a given item"""
+  temporaryLoanType: String
+
+  """Name of the default loan type for a given item"""
+  permanentLoanType: String
+}
+
+"""An error"""
+type Error {
+  """Error message text"""
+  message: String!
+
+  """Error message type"""
+  type: String
+
+  """Error message code"""
+  code: String
 }
 
 """A proxy for a user"""

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -446,6 +446,17 @@ export enum EresourceCreateInventory {
   None = 'None'
 }
 
+/** An error */
+export type Error = {
+  __typename?: 'Error';
+  /** Error message code */
+  code?: Maybe<Scalars['String']['output']>;
+  /** Error message text */
+  message: Scalars['String']['output'];
+  /** Error message type */
+  type?: Maybe<Scalars['String']['output']>;
+};
+
 /** Fees/fines that are used by the entire library system. They can be a set of fees / fines shared throughout the library or fees / fines that are unique to a specific customer service */
 export type FeeFine = {
   __typename?: 'FeeFine';
@@ -2446,6 +2457,7 @@ export enum QuantityIntervalId {
 
 export type Query = {
   __typename?: 'Query';
+  availability?: Maybe<Array<Maybe<RtacHolding>>>;
   campus?: Maybe<Campus>;
   campuses?: Maybe<Array<Maybe<Campus>>>;
   feeFineTypes?: Maybe<Array<Maybe<FeeFine>>>;
@@ -2470,6 +2482,11 @@ export type Query = {
   patronNoticePolicies?: Maybe<Array<Maybe<PatronNoticePolicy>>>;
   requestPolicies?: Maybe<Array<Maybe<RequestPolicy>>>;
   servicePoints?: Maybe<Array<Maybe<ServicePoint>>>;
+};
+
+
+export type QueryAvailabilityArgs = {
+  id?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -2767,6 +2784,45 @@ export enum RequestType {
   Page = 'Page',
   Recall = 'Recall'
 }
+
+/** Real Time Availability Check (RTAC) holding details */
+export type RtacHolding = {
+  __typename?: 'RtacHolding';
+  /** The call number of the holding */
+  callNumber: Scalars['String']['output'];
+  /** The date when the holding will be available */
+  dueDate?: Maybe<Scalars['DateTime']['output']>;
+  /** The FOLIO id of the holding (item) */
+  id: Scalars['String']['output'];
+  /** The location of the holding */
+  location: Scalars['String']['output'];
+  /** Name of the default loan type for a given item */
+  permanentLoanType?: Maybe<Scalars['String']['output']>;
+  /** The availability status of the holding */
+  status: Scalars['String']['output'];
+  /** Name of the temporary loan type for a given item */
+  temporaryLoanType?: Maybe<Scalars['String']['output']>;
+  /** Volume details for the holding (item) */
+  volume?: Maybe<Scalars['String']['output']>;
+};
+
+/** Collection of holdings */
+export type RtacHoldings = {
+  __typename?: 'RtacHoldings';
+  /** Collection of holdings */
+  holdings: Array<RtacHolding>;
+  /** The FOLIO instance identifier */
+  instanceId?: Maybe<Scalars['UUID']['output']>;
+};
+
+/** Batch holdings response */
+export type RtacHoldingsBatch = {
+  __typename?: 'RtacHoldingsBatch';
+  /** Errors */
+  errors?: Maybe<Array<Error>>;
+  /** Real Time Availability Check (RTAC) holding details */
+  holdings?: Maybe<Array<RtacHoldings>>;
+};
 
 /** A date range and associated due date, connected with the parent FixedDueDateSchedule. */
 export type Schedule = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import MaterialTypesAPI from './folio/material-type-api.js'
 import OrdersAPI from './folio/orders-api.js'
 import AuthnAPI from "./folio/authn-api.js"
 import OkapiAPI from "./folio/okapi-api.js"
+import RtacApi from './folio/rtac-api.js'
 import { FolioContext } from './context.js'
 
 // Read the schema.graphql into utf-8 string so we can pass it to Apollo
@@ -86,6 +87,7 @@ const context = async ({ req }: Partial<{ req: express.Request }>) => {
       circulation: new CirculationAPI({ cache, token }),
       materialtypes: new MaterialTypesAPI({ cache, token }),
       orders: new OrdersAPI({ cache, token }),
+      rtac: new RtacApi({ cache, token }),
     }
   }
 }


### PR DESCRIPTION
This is to hopefully get us faster performance for https://github.com/sul-dlss/sul-requests/issues/1676, but we could also use it in SearchWorks to cut down on the overall number of endpoints we're hitting.

Try it out with:
```graphql
query Query($instanceId: String) {
  availability(id: $instanceId) {
    dueDate
    status
    volume
    id
  }
}
```
Using:
```json
{
  "instanceId": "b1e7f6b7-1fe5-5190-925b-f5dfcb54885b"
}
```
For this [periodical in searchworks](https://searchworks-folio-dev.stanford.edu/view/9984192) with many checked-out items.