### PR TITLE
Polyfill Loan.dueDateChangedByHold to prevent errors in mylibrary

### DIFF
--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -1414,6 +1414,7 @@ export type Loan = {
   declaredLostDate?: Maybe<Scalars['DateTime']['output']>;
   /** Date and time when the item is due to be returned */
   dueDate?: Maybe<Scalars['DateTime']['output']>;
+  dueDateChangedByHold?: Maybe<Scalars['Boolean']['output']>;
   /** Is due date changed by recall request */
   dueDateChangedByRecall?: Maybe<Scalars['Boolean']['output']>;
   /** Fees and fines associated with loans */
@@ -4319,6 +4320,7 @@ export type LoanResolvers<ContextType = FolioContext, ParentType extends Resolve
   checkoutServicePointId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
   declaredLostDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   dueDate?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  dueDateChangedByHold?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   dueDateChangedByRecall?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   feesAndFines?: Resolver<Maybe<ResolversTypes['LoanFeesAndFines']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -3924,6 +3924,10 @@ extend type Loan {
   itemEffectiveLocationAtCheckOut: Location
   user: User
   proxyUser: User
+  # TODO: dueDateChangedByHold is not yet implemented in mod-circulation v23.3.5
+  # we polyfill it so that we can still query for it in mylibrary without erroring
+  # see: https://github.com/folio-org/mod-circulation/blob/23b19a862969dece47d3eb6ebc4cde7e43094f91/ramls/loan.json#L307-L311
+  dueDateChangedByHold: Boolean
 }
 
 extend type Hold {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1411,6 +1411,7 @@ export type Loan = {
   declaredLostDate?: Maybe<Scalars['DateTime']['output']>;
   /** Date and time when the item is due to be returned */
   dueDate?: Maybe<Scalars['DateTime']['output']>;
+  dueDateChangedByHold?: Maybe<Scalars['Boolean']['output']>;
   /** Is due date changed by recall request */
   dueDateChangedByRecall?: Maybe<Scalars['Boolean']['output']>;
   /** Fees and fines associated with loans */


### PR DESCRIPTION
This property isn't available until mod-circulation v23.4.0, but
we were erroneously building our schema according to the latest
mod-circulation, so we allowed querying for it despite it not
returning anything.

This patches the query so that mylibrary is still allowed to do
that without erroring, until we are able to upgrade off of
mod-circulation v23.3.5, where the property doesn't exist.

Fixes https://github.com/sul-dlss/mylibrary/issues/914
