### PR TITLE
Add integration tests for the sul-requests queries

### DIFF
--- a/__tests__/integration/query-circ-check-barcode.test.ts
+++ b/__tests__/integration/query-circ-check-barcode.test.ts
@@ -1,0 +1,66 @@
+import { dataSources, queryTestServer } from '../setupJest';
+import assert from 'assert';
+
+it('resolves items', async () => {
+
+    // Source: https://github.com/sul-dlss/sul-requests/blob/35ad5eb23429c838289520eae7a1e91614cf33ae/app/services/folio_graphql_client.rb#L48
+    // in sul-requests `barcode` is passed in directly as a string; replicating that here by hardcoding it below
+    const query = `query CircCheckByBarcode {
+        items(barcode: "10050402-3001") {
+            status {
+                name
+            }
+            barcode
+            dueDate
+            effectiveCallNumberComponents {
+                callNumber
+            }
+            instance {
+                title
+            }
+        }
+    }`;
+
+    // mock the check on loans for this item
+    dataSources.circulation.getLoans = jest.fn().mockResolvedValue([]);
+
+    // mock the resovler for the instance
+    dataSources.instances.getByHoldingsRecordId = jest.fn().mockResolvedValue(
+        {
+            id: '1dd708e8-2a1f-5a18-878d-7c9ff82dae9f',
+            hrid: 'a10050402',
+            source: 'MARC',
+            title: 'Annual report.',
+            instanceTypeId: '30fffe0e-e985-4144-b2e2-1e8179bdb41f',
+            physicalDescriptions: ['v. : ill. ; 28 cm.'],
+            languages: ['eng'],
+        }
+    );
+
+    // mock the internals of items-api
+    dataSources.items.getItems = jest.fn().mockResolvedValue(
+        [{
+            id: '0a03c40c-bd4d-56d6-a59a-15da369fa51f',
+            hrid: 'ai10050402_1_1',
+            holdingsRecordId: '829b8bce-549a-5f11-9376-a558811b34ed',
+            barcode: '10050402-3001',
+            effectiveShelvingOrder: "DREYER'S GRAND ICE CREAM, INC. 1",
+            status: { name: 'Available', date: '2023-08-21T14:31:57.681+00:00' },
+        }]
+    );
+
+    const response = await queryTestServer({
+        query: query,
+        variables: {},
+    });
+
+    // Note the use of Node's assert rather than Jest's expect; if using
+    // TypeScript, `assert`` will appropriately narrow the type of `body`
+    // and `expect` will not.
+    assert(response.body.kind === 'single');
+    expect(response.body.singleResult.errors).toBeUndefined();
+    const items = response.body.singleResult.data.items;
+    expect(items).toBeInstanceOf(Array);
+    expect(items).toHaveLength(1);
+    expect(items[0].status).toEqual({ name: 'Available' });
+});

--- a/__tests__/integration/query-instance-hrid.test.ts
+++ b/__tests__/integration/query-instance-hrid.test.ts
@@ -1,0 +1,167 @@
+import { dataSources, queryTestServer } from '../setupJest';
+import assert from 'assert';
+
+it('resolves instances', async () => {
+
+    // Source: https://github.com/sul-dlss/sul-requests/blob/35ad5eb23429c838289520eae7a1e91614cf33ae/app/services/folio_graphql_client.rb#L71
+    // in sul-requests `hrid` is passed in directly as a string; replicating that here by hardcoding it below
+    const query = `query InstanceByHrid {
+      instances(hrid: "a8585559") {
+        id
+        hrid
+        title
+        identifiers {
+          value
+          identifierTypeObject {
+            name
+          }
+        }
+        instanceType {
+          name
+        }
+        contributors {
+          name
+          primary
+        }
+        publication {
+          dateOfPublication
+          place
+          publisher
+        }
+        editions
+        electronicAccess {
+          materialsSpecification
+          uri
+        }
+        items {
+          id
+          barcode
+          discoverySuppress
+          volume
+          status {
+            name
+          }
+          dueDate
+          materialType {
+            id
+            name
+          }
+          chronology
+          enumeration
+          effectiveCallNumberComponents {
+            callNumber
+          }
+          notes {
+            note
+            itemNoteType {
+              name
+            }
+          }
+          effectiveLocation {
+            id
+            campusId
+            libraryId
+            institutionId
+            code
+            discoveryDisplayName
+            name
+            servicePoints {
+              id
+              code
+              pickupLocation
+            }
+            library {
+              id
+              code
+            }
+            campus {
+              id
+              code
+            }
+            details {
+              pageAeonSite
+              pageMediationGroupKey
+              pageServicePoints {
+                id
+                code
+                name
+              }
+              scanServicePointCode
+              availabilityClass
+              searchworksTreatTemporaryLocationAsPermanentLocation
+            }
+          }
+          permanentLocation {
+            id
+            code
+            details {
+              pageAeonSite
+              pageMediationGroupKey
+              pageServicePoints {
+                id
+                code
+                name
+              }
+              pagingSchedule
+              scanServicePointCode
+            }
+          }
+          temporaryLocation {
+            id
+            code
+            discoveryDisplayName
+          }
+          permanentLoanTypeId
+          temporaryLoanTypeId
+          holdingsRecord {
+            id
+            effectiveLocation {
+              id
+              code
+              details {
+                pageAeonSite
+                pageMediationGroupKey
+                pageServicePoints {
+                  id
+                  code
+                  name
+                }
+                pagingSchedule
+                scanServicePointCode
+              }
+            }
+          }
+        }
+      }
+    }`;
+      
+    // called in the resolver for instanceType
+    dataSources.types.getMapFor = jest.fn().mockResolvedValue(new Map());
+    // mock the internals of instances-api
+    dataSources.instances.getInstances = jest.fn().mockResolvedValue(
+        [{
+          id: '8efc5d53-9c29-5cb8-b0e2-f801fb5dd00c',
+          hrid: 'a8585559',
+          source: 'MARC',
+          title: 'Gelato a mezzanotte : romanzo / Laura Tangorra.',
+          indexTitle: 'Gelato a mezzanotte : romanzo',
+          instanceTypeId: '30fffe0e-e985-4144-b2e2-1e8179bdb41f',
+          statusId: '9634a5ab-9228-4703-baf2-4d12ebc77d56',
+          statusUpdatedDate: '2023-08-21T12:28:20.895+0000'
+        }]);
+
+    const response = await queryTestServer({
+        query: query,
+        variables: {},
+    });
+
+    // Note the use of Node's assert rather than Jest's expect; if using
+    // TypeScript, `assert`` will appropriately narrow the type of `body`
+    // and `expect` will not.
+    assert(response.body.kind === 'single');
+    expect(response.body.singleResult.errors).toBeUndefined();
+    const instances = response.body.singleResult.data.instances;
+    expect(instances).toBeInstanceOf(Array);
+    expect(instances).toHaveLength(1);
+    expect(instances[0].id).toEqual('8efc5d53-9c29-5cb8-b0e2-f801fb5dd00c');
+});

--- a/__tests__/integration/query-service-points.test.ts
+++ b/__tests__/integration/query-service-points.test.ts
@@ -1,9 +1,11 @@
 import { dataSources, queryTestServer } from '../setupJest';
 import assert from 'assert';
 
-it('resolves serivePoints', async () => {
+it('resolves servicePoints', async () => {
 
-    // Source: https://github.com/sul-dlss/mylibrary/blob/4be4b3705c734a7743b019a8450626a6324fe45f/app/services/folio_graphql_client.rb#L55
+    // sul-requests and mylibrary both use this query
+    // https://github.com/sul-dlss/mylibrary/blob/4be4b3705c734a7743b019a8450626a6324fe45f/app/services/folio_graphql_client.rb#L55
+    // https://github.com/sul-dlss/sul-requests/blob/35ad5eb23429c838289520eae7a1e91614cf33ae/app/services/folio_graphql_client.rb#L209 
     const query = `query ServicePoints {
         servicePoints {
           discoveryDisplayName
@@ -13,10 +15,11 @@ it('resolves serivePoints', async () => {
           details {
             isDefaultForCampus
             isDefaultPickup
+            notes
           }
         }
       }`;
-
+      
     // mock the internals of  service-points-api
     dataSources.servicepoints.getServicePoints = jest.fn().mockResolvedValue([{
         "discoveryDisplayName": "Green Library",


### PR DESCRIPTION
This finishes up the foundational testing by adding files for each of the queries sul-requests makes (mylibrary is already covered by prior PR).