### PR TITLE
Trigger Jenkins build on push from Docker Hub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,91 +1,96 @@
 pipeline {
-  agent any
+    agent any
 
-  environment {
-    PROJECT = 'sul-dlss/folio-graphql'
-  }
-
-  stages {
-    stage('FOLIO-test deploy') {
-      environment {
-        DEPLOY_ENVIRONMENT = 'folio-test'
-      }
-
-      when {
-        branch 'main'
-      }
-
-      steps {
-        checkout scm
-
-        sshagent (['sul-devops-team', 'sul-continuous-deployment']){
-          sh '''#!/bin/bash -l
-            # wait for the image to become available?
-            sleep 300
-
-            ssh graphql@sul-folio-graphql-test.stanford.edu \
-            'docker pull suldlss/folio-graphql:main && \
-            docker rm $(docker stop $(docker ps -a -q --filter="name=folio-graphql")) && \
-            docker run -d --env-file ./.env -p 4000:4000 --name folio-graphql suldlss/folio-graphql:main'
-          '''
-        }
-      }
-
-      post {
-        always {
-          build job: '/Continuous Deployment/Slack Deployment Notification', parameters: [
-            string(name: 'PROJECT', value: env.PROJECT),
-            string(name: 'GIT_COMMIT', value: env.GIT_COMMIT),
-            string(name: 'GIT_URL', value: env.GIT_URL),
-            string(name: 'GIT_PREVIOUS_SUCCESSFUL_COMMIT', value: env.GIT_PREVIOUS_SUCCESSFUL_COMMIT),
-            string(name: 'DEPLOY_ENVIRONMENT', value: env.DEPLOY_ENVIRONMENT),
-            string(name: 'TAG_NAME', value: env.TAG_NAME),
-            booleanParam(name: 'SUCCESS', value: currentBuild.resultIsBetterOrEqualTo('SUCCESS')),
-            string(name: 'RUN_DISPLAY_URL', value: env.RUN_DISPLAY_URL)
-          ]
-        }
-      }
+    environment {
+      PROJECT = 'sul-dlss/folio-graphql'
+      GIT_URL = 'https://github.com/sul-dlss/folio-graphql.git'
     }
 
-    stage('FOLIO-prod deploy') {
-      environment {
-        DEPLOY_ENVIRONMENT = 'folio-prod'
-      }
-
-      when {
-        tag "v*"
-      }
-
-      steps {
-        checkout scm
-
-        sshagent (['sul-devops-team', 'sul-continuous-deployment']){
-          sh """#!/bin/bash -l
-            # wait for the image to become available?
-            sleep 300
-
-            ssh graphql@sul-folio-graphql-prod.stanford.edu \
-            'docker pull suldlss/folio-graphql:${env.TAG_NAME} && \
-            docker rm \$(docker stop \$(docker ps -a -q --filter="name=folio-graphql")) && \
-            docker run -d --env-file ./.env -p 4000:4000 --name folio-graphql suldlss/folio-graphql:${env.TAG_NAME}'
-          """
-        }
-      }
-
-      post {
-        always {
-          build job: '/Continuous Deployment/Slack Deployment Notification', parameters: [
-            string(name: 'PROJECT', value: env.PROJECT),
-            string(name: 'GIT_COMMIT', value: env.GIT_COMMIT),
-            string(name: 'GIT_URL', value: env.GIT_URL),
-            string(name: 'GIT_PREVIOUS_SUCCESSFUL_COMMIT', value: env.GIT_PREVIOUS_SUCCESSFUL_COMMIT),
-            string(name: 'DEPLOY_ENVIRONMENT', value: env.DEPLOY_ENVIRONMENT),
-            string(name: 'TAG_NAME', value: env.TAG_NAME),
-            booleanParam(name: 'SUCCESS', value: currentBuild.resultIsBetterOrEqualTo('SUCCESS')),
-            string(name: 'RUN_DISPLAY_URL', value: env.RUN_DISPLAY_URL)
-          ]
-        }
-      }
+    triggers {
+        // the generic-webhook-trigger plugin is installed on the Jenkins server
+        GenericTrigger(
+            genericVariables: [
+                [$class: 'GenericVariable', key: 'image', value: '$.repository.repo_name', defaultValue: ''],
+                [$class: 'GenericVariable', key: 'pusher', value: '$.push_data.pusher', defaultValue: ''],
+                [$class: 'GenericVariable', key: 'tag', value: '$.push_data.tag', defaultValue: ''],
+            ],
+            causeString: 'Docker Hub push event for ${image}:${tag} by ${pusher}',
+            printContributedVariables: true,
+            // The presence of the token in the webhook push is what triggers this specific build.
+            // Dockerhub will send a POST request with this token via our brick-city gateway
+            // See https://hub.docker.com/repository/docker/suldlss/folio-graphql/webhooks (logged in)
+            token: 'foliogql'
+        )
     }
-  }
+
+    stages {
+        stage('Deploy to test server') {
+            environment {
+              DEPLOY_ENVIRONMENT = 'folio-test'
+            }
+            when {
+              // Only run on builds trigggered by GenericWebhookTrigger 
+              // Also check the docker image tag name, based on a push to the main branch in Github
+               expression { currentBuild.getBuildCauses('org.jenkinsci.plugins.gwt.GenericCause') && tag == 'main' }
+             }
+            steps {
+              echo 'Deploying to test server'
+              
+              sshagent (['sul-devops-team', 'sul-continuous-deployment']){
+                sh """#!/bin/bash -l
+                  ssh graphql@sul-folio-graphql-test.stanford.edu \
+                  'docker pull suldlss/folio-graphql:main && \
+                  docker rm -f \$(docker ps -a -q --filter="name=folio-graphql") && \
+                  docker run -d --env-file ./.env -p 4000:4000 --name folio-graphql suldlss/folio-graphql:main'
+                """
+              }
+            }
+            post {
+              always {
+                  build job: '/Continuous Deployment/Slack Deployment Notification', parameters: [
+                  string(name: 'PROJECT', value: env.PROJECT),
+                  string(name: 'TAG_NAME', value: tag),
+                  string(name: 'DEPLOY_ENVIRONMENT', value: env.DEPLOY_ENVIRONMENT),
+                  string(name: 'GIT_URL', value: env.GIT_URL),
+                  booleanParam(name: 'SUCCESS', value: currentBuild.resultIsBetterOrEqualTo('SUCCESS')),
+                  string(name: 'RUN_DISPLAY_URL', value: env.RUN_DISPLAY_URL)
+                ]
+              }
+            }
+        }
+        stage('Deploy to production server') {
+           environment {
+              DEPLOY_ENVIRONMENT = 'folio-prod'
+            }
+            when {
+              // Only run on builds trigggered by GenericWebhookTrigger
+              // Also check the docker image tag name, based on a tagged release in Github
+              expression { currentBuild.getBuildCauses('org.jenkinsci.plugins.gwt.GenericCause') && tag.startsWith('v') }
+            }
+            steps {
+              echo 'Deploying to production server'
+
+              sshagent (['sul-devops-team', 'sul-continuous-deployment']){
+                sh """#!/bin/bash -l
+                  ssh graphql@sul-folio-graphql-prod.stanford.edu \
+                  'docker pull suldlss/folio-graphql:${tag} && \
+                  docker rm -f \$(docker ps -a -q --filter="name=folio-graphql") && \
+                  docker run -d --env-file ./.env -p 4000:4000 --name folio-graphql suldlss/folio-graphql:${tag}'
+                """
+              }
+            } 
+            post {
+              always {
+                  build job: '/Continuous Deployment/Slack Deployment Notification', parameters: [
+                  string(name: 'PROJECT', value: env.PROJECT),
+                  string(name: 'TAG_NAME', value: tag),
+                  string(name: 'DEPLOY_ENVIRONMENT', value: env.DEPLOY_ENVIRONMENT),
+                  string(name: 'GIT_URL', value: env.GIT_URL),
+                  booleanParam(name: 'SUCCESS', value: currentBuild.resultIsBetterOrEqualTo('SUCCESS')),
+                  string(name: 'RUN_DISPLAY_URL', value: env.RUN_DISPLAY_URL)
+                ]
+              }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Push to folio-test and folio-prod respectively for Docker images tagged main and those that start with 'v'

Closes #135 

I just want to point out here that the check in the PR below, `continuous-integration/jenkins/branch` is green passing, but it's not a super useful check because the new code in the Jenkinsfile now has a conditional for whether the build was triggered by the Dockerhub webhook. So builds triggered by pushes to a branch, like this one, just mostly skip all the content.