### PR TITLE
Force Docker containers to use only host VM + Google for DNS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
                   ssh graphql@sul-folio-graphql-test.stanford.edu \
                   'docker pull suldlss/folio-graphql:main && \
                   docker rm -f \$(docker ps -a -q --filter="name=folio-graphql") && \
-                  docker run -d --env-file ./.env -p 4000:4000 --name folio-graphql suldlss/folio-graphql:main'
+                  docker run -d --env-file ./.env -p 4000:4000 --dns=10.111.7.182 --dns=8.8.8.8 --name folio-graphql suldlss/folio-graphql:main'
                 """
               }
             }
@@ -84,7 +84,7 @@ pipeline {
                   ssh graphql@sul-folio-graphql-prod.stanford.edu \
                   'docker pull suldlss/folio-graphql:${imageTag} && \
                   docker rm -f \$(docker ps -a -q --filter="name=folio-graphql") && \
-                  docker run -d --env-file ./.env -p 4000:4000 --name folio-graphql suldlss/folio-graphql:${imageTag}'
+                  docker run -d --env-file ./.env -p 4000:4000 --dns=10.111.7.182 --dns=8.8.8.8 --name folio-graphql suldlss/folio-graphql:${imageTag}'
                 """
               }
             } 


### PR DESCRIPTION
This addresses an issue reported by UIT where the container
was doing an excessive number of DNS lookups to UIT servers.

The container ordinarily has the same /etc/resolv.conf as its
host, but in this case that's undesirable because it allows
the container to discover UIT DNS and make lots of queries
without caching.

Instead, we want to force the container to point at its host's
DNS, which does use dnsmasq and will avoid so many non-cached
lookups.

We keep Google's DNS in as a backup because they can handle it.
