### PR TITLE
Add the Source Storage API so we can fetch marc records

### DIFF
--- a/__tests__/setupJest.ts
+++ b/__tests__/setupJest.ts
@@ -16,6 +16,7 @@ import UsersAPI from '../src/folio/users-api';
 import MaterialTypesAPI from '../src/folio/material-types-api';
 import OrdersAPI from '../src/folio/orders-api';
 import RtacApi from '../src/folio/rtac-api';
+import SourceStorageAPI from '../src/folio/source-storage-api';
 import FolioAPI from '../src/folio/folio-api';
 import AuthnAPI from '../src/folio/authn-api';
 import OkapiAPI from '../src/folio/okapi-api';
@@ -94,6 +95,7 @@ export const dataSources = {
   materialtypes: new MaterialTypesAPI(apiOptions),
   orders: new OrdersAPI(apiOptions),
   rtac: new RtacApi(apiOptions),
+  sourceStorage: new SourceStorageAPI(apiOptions),
   folio: new FolioAPI(apiOptions),
   okapi: new OkapiAPI(apiOptions)
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,6 +10,7 @@ import CirculationAPI from "./folio/circulation-api.js"
 import MaterialTypesAPI from "./folio/material-types-api.js"
 import OrdersAPI from "./folio/orders-api.js"
 import RtacApi from "./folio/rtac-api.js"
+import SourceStorageAPI from "./folio/source-storage-api.js"
 
 export interface FolioContext {
   token: string;
@@ -26,5 +27,6 @@ export interface FolioContext {
     materialtypes: MaterialTypesAPI;
     orders: OrdersAPI;
     rtac: RtacApi;
+    sourceStorage: SourceStorageAPI;
   };
 }

--- a/src/folio/folio-api.ts
+++ b/src/folio/folio-api.ts
@@ -13,7 +13,8 @@ export default class FolioAPI extends RESTDataSource {
     request.headers["X-Okapi-Tenant"] = config.get("folio.tenant")
     request.headers["User-Agent"] = "FolioApiClient"
     request.headers["Accept"] = "application/json, text/plain"
-    request.headers["Content-Type"] = "application/json"
+    // RESTDataSource adds its own lowercase 'content-type' on JSON bodies; capitalizing here duplicates it
+    request.headers["content-type"] = "application/json"
     console.log("[FOLIO]", request.method, this.baseURL, path, request.params.toString());
   }
 

--- a/src/folio/index.ts
+++ b/src/folio/index.ts
@@ -1,4 +1,4 @@
-import { UUIDResolver } from "graphql-scalars"
+import { UUIDResolver, JSONResolver } from "graphql-scalars"
 import {
   Campus,
   ClassificationType,
@@ -280,6 +280,9 @@ export const resolvers: Resolvers = {
     },
     orderLines({ id }, args, { dataSources: { orders } }, info) {
       return orders.getPoLines({ instanceId: id })
+    },
+    marcRecord({ id }, args, { dataSources: { sourceStorage } }, info) {
+      return sourceStorage.getParsedMarcByInstanceId(id)
     }
   },
   InstanceAlternativeTitlesItem: {
@@ -502,5 +505,6 @@ export const resolvers: Resolvers = {
       return orders.getPieces({ poLineId: id })
     }
   },
-  UUID: UUIDResolver
+  UUID: UUIDResolver,
+  JSON: JSONResolver
 }

--- a/src/folio/source-storage-api.ts
+++ b/src/folio/source-storage-api.ts
@@ -1,0 +1,20 @@
+import FolioAPI from "./folio-api.js"
+
+interface SourceRecord {
+  externalIdsHolder?: { instanceId?: string }
+  parsedRecord?: { content?: unknown }
+}
+
+interface SourceRecordsResponse {
+  sourceRecords: SourceRecord[]
+}
+
+export default class SourceStorageAPI extends FolioAPI {
+  async getParsedMarcByInstanceId(instanceId: string): Promise<unknown | null> {
+    const response = await this.post<SourceRecordsResponse>(
+      "/source-storage/source-records?idType=INSTANCE",
+      { body: [instanceId] },
+    )
+    return response.sourceRecords?.[0]?.parsedRecord?.content ?? null
+  }
+}

--- a/src/resolvers-types.ts
+++ b/src/resolvers-types.ts
@@ -17,6 +17,7 @@ export type Scalars = {
   Float: { input: number; output: number; }
   /** A date and time */
   DateTime: { input: any; output: any; }
+  JSON: { input: any; output: any; }
   /** A UUID */
   UUID: { input: any; output: any; }
 };
@@ -838,6 +839,7 @@ export type Instance = {
   items?: Maybe<Array<Maybe<Item>>>;
   /** The set of languages used by the resource */
   languages?: Maybe<Array<Scalars['String']['output']>>;
+  marcRecord?: Maybe<Scalars['JSON']['output']>;
   /** A unique instance identifier matching a client-side bibliographic record identification scheme, in particular for a scenario where multiple separate catalogs with no shared record identifiers contribute to the same Instance in Inventory. A match key is typically generated from select, normalized pieces of metadata in bibliographic records */
   matchKey?: Maybe<Scalars['String']['output']>;
   metadata?: Maybe<Metadata>;
@@ -3537,6 +3539,7 @@ export type ResolversTypes = ResolversObject<{
   ItemNoteType: ResolverTypeWrapper<ItemNoteType>;
   ItemNotesItem: ResolverTypeWrapper<ItemNotesItem>;
   ItemStatus: ResolverTypeWrapper<ItemStatus>;
+  JSON: ResolverTypeWrapper<Scalars['JSON']['output']>;
   Library: ResolverTypeWrapper<Library>;
   License: ResolverTypeWrapper<License>;
   Loan: ResolverTypeWrapper<Loan>;
@@ -3744,6 +3747,7 @@ export type ResolversParentTypes = ResolversObject<{
   ItemNoteType: ItemNoteType;
   ItemNotesItem: ItemNotesItem;
   ItemStatus: ItemStatus;
+  JSON: Scalars['JSON']['output'];
   Library: Library;
   License: License;
   Loan: Loan;
@@ -4269,6 +4273,7 @@ export type InstanceResolvers<ContextType = FolioContext, ParentType extends Res
   instanceTypeId?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
   items?: Resolver<Maybe<Array<Maybe<ResolversTypes['Item']>>>, ParentType, ContextType, Partial<InstanceItemsArgs>>;
   languages?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  marcRecord?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   matchKey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   metadata?: Resolver<Maybe<ResolversTypes['Metadata']>, ParentType, ContextType>;
   modeOfIssuance?: Resolver<Maybe<ResolversTypes['ModeOfIssuance']>, ParentType, ContextType>;
@@ -4558,6 +4563,10 @@ export type ItemStatusResolvers<ContextType = FolioContext, ParentType extends R
   date?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
+
+export interface JsonScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['JSON'], any> {
+  name: 'JSON';
+}
 
 export type LibraryResolvers<ContextType = FolioContext, ParentType extends ResolversParentTypes['Library'] = ResolversParentTypes['Library']> = ResolversObject<{
   campus?: Resolver<Maybe<ResolversTypes['Campus']>, ParentType, ContextType>;
@@ -5574,6 +5583,7 @@ export type Resolvers<ContextType = FolioContext> = ResolversObject<{
   ItemNoteType?: ItemNoteTypeResolvers<ContextType>;
   ItemNotesItem?: ItemNotesItemResolvers<ContextType>;
   ItemStatus?: ItemStatusResolvers<ContextType>;
+  JSON?: GraphQLScalarType;
   Library?: LibraryResolvers<ContextType>;
   License?: LicenseResolvers<ContextType>;
   Loan?: LoanResolvers<ContextType>;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -1,6 +1,7 @@
 # These are non-core graphql types; resolvers are provided by graphql-scalars
 scalar DateTime
 scalar UUID
+scalar JSON
 
 input CqlParams {
   query: String
@@ -4382,6 +4383,7 @@ extend type Instance {
   modeOfIssuance: ModeOfIssuance
   orderLines: [PoLine]
   queueTotalLength: Int
+  marcRecord: JSON
 }
 
 extend type InstanceAlternativeTitlesItem {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -14,6 +14,7 @@ export type Scalars = {
   Float: { input: number; output: number; }
   /** A date and time */
   DateTime: { input: any; output: any; }
+  JSON: { input: any; output: any; }
   /** A UUID */
   UUID: { input: any; output: any; }
 };
@@ -835,6 +836,7 @@ export type Instance = {
   items?: Maybe<Array<Maybe<Item>>>;
   /** The set of languages used by the resource */
   languages?: Maybe<Array<Scalars['String']['output']>>;
+  marcRecord?: Maybe<Scalars['JSON']['output']>;
   /** A unique instance identifier matching a client-side bibliographic record identification scheme, in particular for a scenario where multiple separate catalogs with no shared record identifiers contribute to the same Instance in Inventory. A match key is typically generated from select, normalized pieces of metadata in bibliographic records */
   matchKey?: Maybe<Scalars['String']['output']>;
   metadata?: Maybe<Metadata>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import OrdersAPI from './folio/orders-api.js'
 import AuthnAPI from "./folio/authn-api.js"
 import OkapiAPI from "./folio/okapi-api.js"
 import RtacApi from './folio/rtac-api.js'
+import SourceStorageAPI from './folio/source-storage-api.js'
 import { FolioContext } from './context.js'
 
 // Read the schema.graphql into utf-8 string so we can pass it to Apollo
@@ -88,6 +89,7 @@ const context = async ({ req }: Partial<{ req: express.Request }>) => {
       materialtypes: new MaterialTypesAPI({ cache, token }),
       orders: new OrdersAPI({ cache, token }),
       rtac: new RtacApi({ cache, token }),
+      sourceStorage: new SourceStorageAPI({ cache, token }),
     }
   }
 }


### PR DESCRIPTION
We'd like to be able to pull the marc in, so that Requests/My Library can compute document formats.

Instance with marc:
`{ instance(id: "16128bc2-1984-5e4d-b698-71e24ee41cc3") { hrid marcRecord } }`

Instance with no marc:
`{ instance(id: "8070bc31-b8f1-4b3f-93fb-3678b6924885") { hrid marcRecord } }`